### PR TITLE
integration with the system zlib and libturbojpeg

### DIFF
--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -29,15 +29,22 @@ add_executable(dcm2niix
         nii_ortho.cpp
         nii_dicom_batch.cpp)
 
-FIND_PACKAGE(ZLIB QUIET)
-if(ZLIB_FOUND)
-  TARGET_LINK_LIBRARIES(dcm2niix z)
-  ADD_DEFINITIONS(-DmyDisableMiniZ)
-else(ZLIB_FOUND)
-  #We now use miniz, so we can still deal with zcompressed files
-  #The following line would disable z compression
-  # ADD_DEFINITIONS(-DmyDisableZlib)
-endif(ZLIB_FOUND)
+option(USE_SYSTEM_ZLIB "Use the system zlib" OFF)
+if (USE_SYSTEM_ZLIB)
+  find_package(ZLIB REQUIRED)
+  add_definitions(-DmyDisableMiniZ)
+  target_include_directories(dcm2niix PRIVATE ${ZLIB_INCLUDE_DIRS})
+  target_link_libraries(dcm2niix ${ZLIB_LIBRARIES})
+endif ()
+
+option(USE_SYSTEM_TURBOJPEG "Use the system TurboJPEG" OFF)
+if (USE_SYSTEM_TURBOJPEG)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(TurboJPEG libturbojpeg)
+  add_definitions(-DmyTurboJPEG)
+  target_include_directories(dcm2niix PRIVATE ${TurboJPEG_INCLUDE_DIRS})
+  target_link_libraries(dcm2niix ${TurboJPEG_LIBRARIES})
+endif ()
 
 if (BATCH_VERSION)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")


### PR DESCRIPTION
This PR enables **optional** integration with the system zlib and libturbojpeg libraries, which is a desirable feature for Linux distributions such as Debian or Fedora.

It introduces 2 new options, `USE_SYSTEM_ZLIB` and `USE_SYSTEM_TURBOJPEG` to selectively enable compilation with either of the system libraries. They are set to `OFF` by default in order to keep the old behaviour.

No system libraries:
```
cmake .. && make
ldd ../bin/dcm2niix
```
```
	linux-vdso.so.1 (0x00007ffe2477a000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fbd193c2000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fbd19024000)
	/lib64/ld-linux-x86-64.so.2 (0x000055f9a9efd000)
```

Use the system zlib:
```
cmake .. -DUSE_SYSTEM_ZLIB=ON && make
ldd ../bin/dcm2niix
```
```
	linux-vdso.so.1 (0x00007ffd3fb1b000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fa79e481000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fa79e17d000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa79dddf000)
	/lib64/ld-linux-x86-64.so.2 (0x0000561c3f7fa000)
```

Use the system zlib and libturbojpeg:
```
cmake .. -DUSE_SYSTEM_ZLIB=ON -DUSE_SYSTEM_TURBOJPEG=ON && make
ldd ../bin/dcm2niix
```
```
	linux-vdso.so.1 (0x00007ffc04176000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f9ecf9f8000)
	libturbojpeg.so.0 => /usr/lib/x86_64-linux-gnu/libturbojpeg.so.0 (0x00007f9ecf785000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f9ecf481000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f9ecf0e3000)
	/lib64/ld-linux-x86-64.so.2 (0x00005614c50ef000)
```