### PR TITLE
Feature bids date - bugfix

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -371,8 +371,8 @@ void nii_SaveBIDS(char pathoutname[], struct TDICOMdata d, struct TDCMopts opts,
      if (count) {
         // ISO 8601 specifies a sign must exist for distant years.
         fprintf(fp, "\t\"AcquisitionDateTime\": ");
-        fprintf(fp, (ayear >= 0 && ayear <= 9999) ? "%4d" : "%+4d", ayear);
-        fprintf(fp, "-%02d-%02dT%02d:%02d:%02.6f,\n", amonth, aday, ahour, amin, asec);
+        fprintf(fp, (ayear >= 0 && ayear <= 9999) ? "\"%4d" : "\"%+4d", ayear);
+        fprintf(fp, "-%02d-%02dT%02d:%02d:%02.6f\",\n", amonth, aday, ahour, amin, asec);
         }
   }
 


### PR DESCRIPTION
The AcquisitionDateTime on the BIDS JSON sidecar wasn't formatted properly as a string.
That would case some JSON parsers to choke:

> "AcquisitionDateTime": 2016-04-12T17:29:9.218750,

```
$ jq .AcquisitionDateTime $example
parse error: Invalid numeric literal at line 5, column 38
```

> "AcquisitionDateTime": "2016-04-12T17:29:9.218750",

```
$ jq .AcquisitionDateTime $example
"2016-04-12T17:29:9.218750"
```