### PR TITLE
specify older cmake version in minimum requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(dcm2niix)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 
 include(ucm.cmake)
 

--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8)
 project(console)
 set(PROGRAMS dcm2niix)
 


### PR DESCRIPTION
Change cmake minimum requirements to 2.8 so that Ubuntu 14.04 is still supported. Previously one file set the minimum at 2.6 while another set it at 3.0. 