### PR TITLE
Changes from divest 0.2

### DIFF
--- a/console/jpg_0XC3.cpp
+++ b/console/jpg_0XC3.cpp
@@ -185,7 +185,7 @@ unsigned char *  decode_JPEG_SOF_0XC3 (const char *fn, int skipBytes, bool verbo
                     l[lFrameCount].DHTliRA[lInc] = readByte(lRawRA, &lRawPos, lRawSz);
                     DHTnLi = DHTnLi +  l[lFrameCount].DHTliRA[lInc];
                     if (l[lFrameCount].DHTliRA[lInc] != 0) l[lFrameCount].MaxHufSi = lInc;
-                    if (verbose) printf("DHT has %d combinations with %d bits\n", l[lFrameCount].DHTliRA[lInc], lInc);
+                    if (verbose) printMessage("DHT has %d combinations with %d bits\n", l[lFrameCount].DHTliRA[lInc], lInc);
                     
                 }
                 if (DHTnLi > 17) {
@@ -205,7 +205,7 @@ unsigned char *  decode_JPEG_SOF_0XC3 (const char *fn, int skipBytes, bool verbo
                             btS1 = readByte(lRawRA, &lRawPos, lRawSz);
                             l[lFrameCount].HufVal[lIncY] = btS1;
                             l[lFrameCount].MaxHufVal = btS1;
-                            if (verbose) printf("DHT combination %d has a value of %d\n", lIncY, btS1);
+                            if (verbose) printMessage("DHT combination %d has a value of %d\n", lIncY, btS1);
                             if (btS1 <= 16) //unsigned ints ALWAYS >0, so no need for(btS1 >= 0)
                                 l[lFrameCount].HufSz[lIncY] = lInc;
                             else {
@@ -288,7 +288,7 @@ unsigned char *  decode_JPEG_SOF_0XC3 (const char *fn, int skipBytes, bool verbo
         lIncO++;
     } while (lIncO > 0);
     if (lIsRestartSegments != 0) //detects both restart and corruption https://groups.google.com/forum/#!topic/comp.protocols.dicom/JUuz0B_aE5o
-        printf("Warning: detected restart segments, decompress with dcmdjpeg or gdcmconv 0xFF%02X.\n", lIsRestartSegments);
+        printWarning("Detected restart segments, decompress with dcmdjpeg or gdcmconv 0xFF%02X.\n", lIsRestartSegments);
     //NEXT: some RGB images use only a single Huffman table for all 3 colour planes. In this case, replicate the correct values
     //NEXT: prepare lookup table
     for (int lFrameCount = 1; lFrameCount <= lnHufTables; lFrameCount ++) {

--- a/console/nifti1_io_core.cpp
+++ b/console/nifti1_io_core.cpp
@@ -29,6 +29,9 @@
 #include <unistd.h>
 #endif
 
+#include "print.h"
+
+#ifndef HAVE_R
 void nifti_swap_8bytes( size_t n , void *ar )    // 4 bytes at a time
 {
     size_t ii ;
@@ -75,6 +78,7 @@ void nifti_swap_2bytes( size_t n , void *ar )    // 2 bytes at a time
     }
     return ;
 }
+#endif
 
 int isSameFloat (float a, float b) {
     return (fabs (a - b) <= FLT_EPSILON);
@@ -147,7 +151,7 @@ mat44 nifti_dicom2mat(float orient[7], float patientPosition[4], float xyzMM[4])
     mat33 Q, diagVox;
     Q.m[0][0] = orient[1]; Q.m[0][1] = orient[2] ; Q.m[0][2] = orient[3] ; // load Q
     Q.m[1][0] = orient[4]; Q.m[1][1] = orient[5] ; Q.m[1][2] = orient[6];
-    //printf("Orient %g %g %g %g %g %g\n",orient[1],orient[2],orient[3],orient[4],orient[5],orient[6] );
+    //printMessage("Orient %g %g %g %g %g %g\n",orient[1],orient[2],orient[3],orient[4],orient[5],orient[6] );
     /* normalize row 1 */
     double val = Q.m[0][0]*Q.m[0][0] + Q.m[0][1]*Q.m[0][1] + Q.m[0][2]*Q.m[0][2] ;
     if( val > 0.0l ){
@@ -184,6 +188,7 @@ mat44 nifti_dicom2mat(float orient[7], float patientPosition[4], float xyzMM[4])
     return Q44;
 }
 
+#ifndef HAVE_R
 float nifti_mat33_determ( mat33 R )   /* determinant of 3x3 matrix */
 {
     double r11,r12,r13,r21,r22,r23,r31,r32,r33 ;
@@ -206,6 +211,7 @@ mat33 nifti_mat33_mul( mat33 A , mat33 B )  /* multiply 2 3x3 matrices */
             + A.m[i][2] * B.m[2][j] ;
     return C ;
 }
+#endif
 
 mat44 nifti_mat44_mul( mat44 A , mat44 B )  /* multiply 2 3x3 matrices */
 {
@@ -229,6 +235,7 @@ mat33 nifti_mat33_transpose( mat33 A )  /* transpose 3x3 matrix */
     return B;
 }
 
+#ifndef HAVE_R
 mat33 nifti_mat33_inverse( mat33 R )   /* inverse of 3x3 matrix */
 {
     double r11,r12,r13,r21,r22,r23,r31,r32,r33 , deti ;
@@ -485,7 +492,7 @@ mat44 nifti_mat44_inverse( mat44 R )
     Q.m[3][3] = (deti == 0.0l) ? 0.0l : 1.0l ; // failure flag if deti == 0
     return Q ;
 }
-
+#endif
 
 
 

--- a/console/nifti1_io_core.h
+++ b/console/nifti1_io_core.h
@@ -4,6 +4,11 @@
 #ifndef _NIFTI_IO_CORE_HEADER_
 #define _NIFTI_IO_CORE_HEADER_
 
+#ifdef HAVE_R
+#define STRICT_R_HEADERS
+#include "RNifti.h"
+#endif
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -11,12 +16,14 @@ extern "C" {
 #include <stdbool.h>
 #include <string.h>
 
+#ifndef HAVE_R
 typedef struct {                   /** 4x4 matrix struct **/
     float m[3][3] ;
 } mat33 ;
 typedef struct {                   /** 4x4 matrix struct **/
     float m[4][4] ;
 } mat44 ;
+#endif
 typedef struct {                   /** x4 vector struct **/
     float v[4] ;
 } vec4 ;

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -1870,7 +1870,7 @@ unsigned char * nii_loadImgCore(char* imgname, struct nifti_1_header hdr, int bi
          return NULL;
     }
 	fseek(file, 0, SEEK_END);
-	size_t fileLen=ftell(file);
+	long fileLen=ftell(file);
     if (fileLen < (imgszRead+hdr.vox_offset)) {
         printMessage("File not large enough to store image data: %s\n", imgname);
         return NULL;
@@ -2442,7 +2442,7 @@ int isDICOMfile(const char * fname) { //0=NotDICOM, 1=DICOM, 2=Maybe(not Part 10
     FILE *fp = fopen(fname, "rb");
 	if (!fp)  return 0;
 	fseek(fp, 0, SEEK_END);
-	size_t fileLen=ftell(fp);
+	long fileLen=ftell(fp);
     if (fileLen < 256) {
         fclose(fp);
         return 0;
@@ -2489,7 +2489,7 @@ struct TDICOMdata readDICOMv(char * fname, int isVerbose, int compressFlag, stru
 		return d;
 	}
 	fseek(file, 0, SEEK_END);
-	size_t fileLen=ftell(file); //Get file length
+	long fileLen=ftell(file); //Get file length
     if (fileLen < 256) {
         printMessage( "File too small to be a DICOM image %s\n", fname);
 		return d;
@@ -2506,7 +2506,7 @@ struct TDICOMdata readDICOMv(char * fname, int isVerbose, int compressFlag, stru
 	size_t sz = fread(buffer, 1, fileLen, file);
 	fclose(file);
 	if (sz < fileLen) {
-         printError("Only loaded %zu of %lld bytes for %s\n", sz, fileLen, fname);
+         printError("Only loaded %zu of %ld bytes for %s\n", sz, fileLen, fname);
          return d;
     }
 	//bool isPart10prefix = true; //assume 132 byte header http://nipy.bic.berkeley.edu/nightly/nibabel/doc/dicom/dicom_intro.html

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -1,6 +1,8 @@
 #include <stdbool.h>
 #include <string.h>
+#ifndef HAVE_R
 #include "nifti1.h"
+#endif
 
 #ifndef MRIpro_nii_dcm_h
 

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -10,14 +10,27 @@ extern "C" {
 
 #include <stdbool.h>
 #include <string.h>
+#ifndef HAVE_R
 #include "nifti1.h"
-#include "nifti1.h"
+#endif
 #include "nii_dicom.h"
+
+#ifdef HAVE_R
+    struct TDicomSeries {
+        TDICOMdata representativeData;
+        std::vector<std::string> files;
+    };
+#endif
 
     struct TDCMopts {
         bool isGz, isFlipY,  isCreateBIDS, isCreateText, isTiltCorrect, isRGBplanar, isOnlySingleFile, isForceStackSameSeries, isCrop;
         int isVerbose, compressFlag; //support for compressed data 0=none,
         char filename[512], outdir[512], indir[512], pigzname[512], optsname[512], indirParent[512];
+#ifdef HAVE_R
+        bool isScanOnly;
+        void *imageList;
+        std::vector<TDicomSeries> series;
+#endif
     };
     void saveIniFile (struct TDCMopts opts);
     void setDefaultOpts (struct TDCMopts *opts, const char * argv[]); //either "setDefaultOpts(opts,NULL)" or "setDefaultOpts(opts,argv)" where argv[0] is path to search

--- a/console/nii_ortho.cpp
+++ b/console/nii_ortho.cpp
@@ -1,4 +1,6 @@
+#ifndef HAVE_R
 #include "nifti1.h"
+#endif
 #include "nifti1_io_core.h"
 #include "nii_ortho.h"
 #include <math.h>
@@ -18,6 +20,8 @@
 
 #endif
 //#define MY_DEBUG //verbose text reporting
+
+#include "print.h"
 
 typedef struct  {
     int v[3];
@@ -313,7 +317,7 @@ vec3 minCornerFlip (struct nifti_1_header *h, vec3i* flipVec)
 
 #ifdef MY_DEBUG
 void reportMat44o(char *str, mat44 A) {
-    printf("%s = [%g %g %g %g; %g %g %g %g; %g %g %g %g; 0 0 0 1]\n",str,
+    printMessage("%s = [%g %g %g %g; %g %g %g %g; %g %g %g %g; 0 0 0 1]\n",str,
            A.m[0][0],A.m[0][1],A.m[0][2],A.m[0][3],
            A.m[1][0],A.m[1][1],A.m[1][2],A.m[1][3],
            A.m[2][0],A.m[2][1],A.m[2][2],A.m[2][3]);
@@ -331,14 +335,14 @@ unsigned char *  nii_setOrtho(unsigned char* img, struct nifti_1_header *h) {
     }
     if (h->sform_code == NIFTI_XFORM_UNKNOWN) {
          #ifdef MY_DEBUG
-         printf("No Q or S spatial transforms - assuming canonical orientation");
+         printMessage("No Q or S spatial transforms - assuming canonical orientation");
          #endif
          return img;
     }
     mat44 s = sFormMat(h);
     if (isMat44Canonical( s)) {
         #ifdef MY_DEBUG
-        printf("Image in perfect alignment: no need to reorient");
+        printMessage("Image in perfect alignment: no need to reorient");
         #endif
         return img;
     }
@@ -348,7 +352,7 @@ unsigned char *  nii_setOrtho(unsigned char* img, struct nifti_1_header *h) {
     vec3i orientVec = setOrientVec(orient);
     if ((orientVec.v[0]==1) && (orientVec.v[1]==2) && (orientVec.v[2]==3) ) {
         #ifdef MY_DEBUG
-        printf("Image already near best orthogonal alignment: no need to reorient\n");
+        printMessage("Image already near best orthogonal alignment: no need to reorient\n");
         #endif
         return img;
     }
@@ -365,8 +369,8 @@ unsigned char *  nii_setOrtho(unsigned char* img, struct nifti_1_header *h) {
         h->dim[3] = h->dim[3] / 3;
     }
     #ifdef MY_DEBUG
-    printf("NewRotation= %d %d %d\n", orientVec.v[0],orientVec.v[1],orientVec.v[2]);
-    printf("MinCorner= %.2f %.2f %.2f\n", minMM.v[0],minMM.v[1],minMM.v[2]);
+    printMessage("NewRotation= %d %d %d\n", orientVec.v[0],orientVec.v[1],orientVec.v[2]);
+    printMessage("MinCorner= %.2f %.2f %.2f\n", minMM.v[0],minMM.v[1],minMM.v[2]);
     reportMat44o((char*)"input",s);
     s = sFormMat(h);
     reportMat44o((char*)"output",s);

--- a/console/nii_ortho.h
+++ b/console/nii_ortho.h
@@ -5,7 +5,10 @@
 extern "C" {
 #endif
     
+#ifndef HAVE_R
 #include "nifti1.h"
+#endif
+    
     void mat2sForm (struct nifti_1_header *h, mat44 s);
     bool isMat44Canonical(mat44 R);
 	unsigned char *  nii_setOrtho(unsigned char* img, struct nifti_1_header *h);

--- a/console/print.h
+++ b/console/print.h
@@ -11,9 +11,9 @@
 	#ifdef HAVE_R
 		#define R_USE_C99_IN_CXX
 		#include <R_ext/Print.h>
-		#define printMessage Rprintf
-		#define printWarning(...) { REprintf("Warning: "); REprintf(__VA_ARGS__); }
-		#define printError(...) { REprintf("Error: "); REprintf(__VA_ARGS__); }
+		#define printMessage(...) { Rprintf("[dcm2niix info] "); Rprintf(__VA_ARGS__); }
+		#define printWarning(...) { Rprintf("[dcm2niix WARNING] "); Rprintf(__VA_ARGS__); }
+		#define printError(...) { Rprintf("[dcm2niix ERROR] "); Rprintf(__VA_ARGS__); }
 	#else
 		#ifdef myUseCOut
 			//for piping output to Qtextedit


### PR DESCRIPTION
This PR contains changes to `dcm2niix` code made in support of `divest`, as of version 0.2.0. Most are R-specific and hence fenced with `#ifdef HAVE_R`, but there are a few other tweaks:

- Arranging for `nii_saveCrop` to return a status code, similar to other, related functions.
- Adding braces to avoid compilation problems when the `divest` versions of the various print macros are used.
- Avoiding use of the `long long` type, which [can create portability problems](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#FOOT69).