### PR TITLE
Add SequenceName BIDS entry

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -365,6 +365,8 @@ void nii_SaveBIDS(char pathoutname[], struct TDICOMdata d, struct TDCMopts opts,
 		fprintf(fp, "\t\"ProcedureStepDescription\": \"%s\",\n", d.procedureStepDescription );
 	if (strlen(d.protocolName) > 0)
 		fprintf(fp, "\t\"ProtocolName\": \"%s\",\n", d.protocolName );
+	if (strlen(d.sequenceName) > 0)
+		fprintf(fp, "\t\"SequenceName\": \"%s\",\n", d.sequenceName );
 	if (strlen(d.imageType) > 0) {
 		fprintf(fp, "\t\"ImageType\": [\"");
 		bool isSep = false;


### PR DESCRIPTION
Hi Chris,
I add the `SequenceName` entry in the BIDS file to be able to keep this info when I later rename the images according to the BIDS naming scheme.
Here is my two cents I you wish to include it in your code.
Best,
Mikaël