### PR TITLE
Fencing memmem implementation based on OS, not compiler

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -332,7 +332,7 @@ bool isDerived(struct TDICOMdata d) {
 		return true;
 }
 
-#ifdef _MSC_VER
+#if defined(_WIN64) || defined(_WIN32)
 //https://opensource.apple.com/source/Libc/Libc-1044.1.2/string/FreeBSD/memmem.c
 /*-
  * Copyright (c) 2005 Pascal Gloor <pascal.gloor@spale.com>


### PR DESCRIPTION
I don't know the Windows platform well, but my AppVeyor builds for `divest` are failing using the latest release of `dcm2niix`, due to missingness of `memmem`. Since the presence of this function is presumably a question of system headers rather than compiler environment, it seems like fencing the inline `memmem` implementation for Windows, rather than Visual Studio specifically, might be a more general solution. Indeed, `divest` seems to build properly on Windows like this.