### PR TITLE
ENH: add dcm_qa as a submodule and use in travis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dcm_qa"]
+	path = dcm_qa
+	url = http://github.com/neurolabusc/dcm_qa

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,13 @@ matrix:
     - os: osx
       env: TARGET=mac
 
+before_install:
+  - git submodule update --init --depth=3 dcm_qa
+
 script:
   - mkdir build && cd build && cmake -DBATCH_VERSION=ON -DUSE_OPENJPEG=ON .. && make && cd -
+  - export PATH=$PWD/build/bin:$PATH
+  - cd dcm_qa; ./batch.sh
 
 before_deploy:
   - export DATE=`date +%-d-%b-%Y`


### PR DESCRIPTION
- [ ] verify that it all works ;)  especially in view of https://github.com/neurolabusc/dcm_qa/issues/5

would require learning a bit about git modules but IMHO it is the correct way to do it and bind version (commit) of dcm_qa into specific state of dcm2niix.  If anything changes within dcm_qa, you would need first o push dcm_qa to github and then commit the change here