### PR TITLE
Ability to specify which series to convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ If you have any problems with the cmake build script described above or want to 
   - [dcm2niir](https://github.com/muschellij2/dcm2niir) R wrapper for dcm2niix/dcm2nii.
   - [divest](https://github.com/jonclayden/divest) R interface to dcm2niix.
   - [sci-tran dcm2niix](https://github.com/scitran-apps/dcm2niix) docker.
-  - [neuro_docker](https://github.com/Neurita/neuro_docker) includes dcm2niix as part of a provides a single, static Dockerfile.
+  - [neuro_docker](https://github.com/Neurita/neuro_docker) includes dcm2niix as part of a single, static Dockerfile.
   - [neurodocker](https://github.com/kaczmarj/neurodocker) generates [custom](https://github.com/rordenlab/dcm2niix/issues/138) Dockerfiles given specific versions of neuroimaging software.
   - [dcm2niix_afni](https://afni.nimh.nih.gov/pub/dist/doc/program_help/dcm2niix_afni.html) is a version of dcm2niix included with the [AFNI](https://afni.nimh.nih.gov/) distribution.
   - [MRIcroGL](https://github.com/neurolabusc/MRIcroGL) is available for MacOS, Linux and Windows and provides a graphical interface for dcm2niix. You can get compiled copies from the [MRIcroGL NITRC web site](https://www.nitrc.org/projects/mricrogl/).

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,6 @@
 ## Versions
 
-4-Dev-2017
+4-Dec-2017
  - Handle implicit VR DICOMs where [critical values nested in sequence groups (SQ)](https://github.com/rordenlab/dcm2niix/commit/7f5649c6fe6ed366d07776aa54397b50f6641aff)
  - Better support for [PAR/REC files with segmented 3D EPI](https://github.com/rordenlab/dcm2niix/commit/66cdf2dcc60d55a6ef37f5a6db8d500d3eeb7c88).
  - Allow Protocol Name to be [empty](https://github.com/rordenlab/dcm2niix/commit/94f3129898ba83bf310c9ff28e994f29feb13068).

--- a/console/main_console.cpp
+++ b/console/main_console.cpp
@@ -89,6 +89,7 @@ void showHelp(const char * argv[], struct TDCMopts opts) {
     printf("  -h : show help\n");
     printf("  -i : ignore derived, localizer and 2D images (y/n, default n)\n");
     printf("  -m : merge 2D slices from same series regardless of study time, echo, coil, orientation, etc. (y/n, default n)\n");
+    printf("  -n : only convert this series number - can be used up to %i times (default convert all)\n", MAX_NUM_SERIES);
     printf("  -o : output directory (omit to save to input folder)\n");
     printf("  -p : Philips precise float (not display) scaling (y/n, default y)\n");
     printf("  -s : single file mode, do not convert other images in folder (y/n, default n)\n");
@@ -279,6 +280,15 @@ int main(int argc, const char * argv[])
             } else if ((argv[i][1] == 'o') && ((i+1) < argc)) {
                 i++;
                 strcpy(opts.outdir,argv[i]);
+            } else if ((argv[i][1] == 'n') && ((i+1) < argc)) {
+              if (opts.numSeries < MAX_NUM_SERIES) {
+                  i++;
+                  opts.seriesNumber[opts.numSeries] = atoi(argv[i]);
+                  opts.numSeries += 1;
+                }
+                else {
+                  printf("Warning: too many series specified, ignoring -n %s\n", argv[i]);
+                }
             } else
              printf(" Error: invalid option '%s %s'\n", argv[i], argv[i+1]);;
             lastCommandArg = i;

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2470,6 +2470,18 @@ int saveDcm2Nii(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dcmLis
         imgM = nii_flipZ(imgM, &hdr0);
         sliceDir = abs(sliceDir); //change this, we have flipped the image so GE DTI bvecs no longer need to be flipped!
     }
+    // skip converting if user has specified one or more series, but has not specified this one
+    if (opts.numSeries > 0) {
+      int i = 0;
+      for (; i < opts.numSeries; i++) {
+        if (opts.seriesNumber[i] == dcmList[dcmSort[0].indx].seriesNum) {
+          break;
+        }
+      }
+      if (i == opts.numSeries) {
+        return EXIT_SUCCESS;
+      }
+    }
     //move before headerDcm2Nii2 checkSliceTiming(&dcmList[indx0], &dcmList[indx1]);
     //nii_SaveBIDS(pathoutname, dcmList[dcmSort[0].indx], opts, dti4D, &hdr0, nameList->str[dcmSort[0].indx]);
     nii_SaveBIDS(pathoutname, dcmList[dcmSort[0].indx], opts, &hdr0, nameList->str[dcmSort[0].indx]);
@@ -3184,6 +3196,8 @@ void setDefaultOpts (struct TDCMopts *opts, const char * argv[]) { //either "set
         opts->isVerbose = false;
 #endif
     opts->isTiltCorrect = true;
+    opts->numSeries = 0;
+    memset(opts->seriesNumber, 0, sizeof(opts->seriesNumber));
     strcpy(opts->filename,"%f_%p_%t_%s");
 } // setDefaultOpts()
 

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -22,10 +22,13 @@ extern "C" {
     };
 #endif
 
+#define MAX_NUM_SERIES 16
+
     struct TDCMopts {
         bool isSave3D,isGz, isFlipY,  isCreateBIDS, isSortDTIbyBVal, isAnonymizeBIDS, isOnlyBIDS, isCreateText, isIgnoreDerivedAnd2D, isPhilipsFloatNotDisplayScaling, isTiltCorrect, isRGBplanar, isOnlySingleFile, isForceStackSameSeries, isCrop;
         int isVerbose, compressFlag, gzLevel; //support for compressed data 0=none,
         char filename[512], outdir[512], indir[512], pigzname[512], optsname[512], indirParent[512], imageComments[24];
+        long seriesNumber[MAX_NUM_SERIES], numSeries;
 #ifdef HAVE_R
         bool isScanOnly;
         void *imageList;


### PR DESCRIPTION
This PR proposes a small feature addition to the `dcm2niix` command line interface, which allows the user to specify one or more DICOM data series that they wish to convert. 

My interest is in GUI development and data visualisation, so I would like to use `dcm2niix` in the following way:

1. Identify the DICOM series that are present, by only outputting BIDS sidecar `.json` files:
   `dcm2niix -b o ...`

2. Prompt the user to select which data series they wish to view.

3. Convert those series from DICOM to NIFTI, using the proposed `-n` command line flag. For example, if the user only wishes to convert series 2 and 4, they would type:
   `dcm2niix -n 2 -n 4 ...`

I am proposing this feature purely from a performance point of view - by limiting which series get converted, computational time, memory, and hard disk usage can all be kept down to only what is necessary.

I figured that, in the event that multiple DICOM series with the same series number are present, `dcm2niix`'s present behaviour of appending an alphabetical suffix to the series number in the generated file names would be acceptable.

However, I am not particularly tied to use of the series number, so feel free to propose an alternate method of identifying which series to be converted!