### PR TITLE
Avoid using defunct "register" keyword in C++

### DIFF
--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -20,7 +20,6 @@ set(PROGRAMS dcm2niix)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     # using Clang
-    add_definitions(-Wno-deprecated-register)
     add_definitions(-fno-caret-diagnostics)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip")
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -384,7 +384,7 @@ void nii_SaveText(char pathoutname[], struct TDICOMdata d, struct TDCMopts opts,
  * SUCH DAMAGE.
  */
 const void * memmem(const char *l, size_t l_len, const char *s, size_t s_len) {
-	register char *cur, *last;
+	char *cur, *last;
 	const char *cl = (const char *)l;
 	const char *cs = (const char *)s;
 	/* we need something to compare */

--- a/console/ujpeg.cpp
+++ b/console/ujpeg.cpp
@@ -598,7 +598,7 @@ NJ_INLINE void njDecodeDHT(void) {
             remain -= currcnt << (16 - codelen);
             if (remain < 0) njThrow(NJ_SYNTAX_ERROR);
             for (i = 0;  i < currcnt;  ++i) {
-                register unsigned char code = nj.pos[i];
+                unsigned char code = nj.pos[i];
                 for (j = spread;  j;  --j) {
                     vlc->bits = (unsigned char) codelen;
                     vlc->code = code;
@@ -840,9 +840,9 @@ NJ_INLINE void njConvert(void) {
         const unsigned char *pcr = nj.comp[2].pixels;
         for (yy = nj.height;  yy;  --yy) {
             for (x = 0;  x < nj.width;  ++x) {
-                register int y = py[x] << 8;
-                register int cb = pcb[x] - 128;
-                register int cr = pcr[x] - 128;
+                int y = py[x] << 8;
+                int cb = pcb[x] - 128;
+                int cr = pcr[x] - 128;
                 *prgb++ = njClip((y            + 359 * cr + 128) >> 8);
                 *prgb++ = njClip((y -  88 * cb - 183 * cr + 128) >> 8);
                 *prgb++ = njClip((y + 454 * cb            + 128) >> 8);


### PR DESCRIPTION
The `register` keyword was [deprecated in C++11 and removed in C++17](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4340), and CRAN now requires C++ code included in R packages not to use it, to avoid problems on their build farm (notably with the upcoming `clang` 6.0). This small PR removes the keyword where it is used in C++ code within `dcm2niix`, and also drops the`clang` flag telling the compiler not to complain about the deprecation (which should no longer be necessary).