### PR TITLE
Improved support of Philips and GE features

### DIFF
--- a/Philips/README.md
+++ b/Philips/README.md
@@ -10,29 +10,37 @@ The Image Patient Position (0020,0032) tag is required to determine the position
 
 In practice, this complication has several major implications. First, not all software translate private SQs well. One potential problem is when the implicit VRs are saved as implicit VRs. This can obscure the fact that 2005,140F is an SQ. Indeed, some tools will convert the private SQ type as a "UN" unknown type and add another public sequence. This can confuse reading software.
 
-Furthermore, in the real world there are many Philips DICOM images that ONLY contain IPP inside SQ 2005,140F. It is not clear if this reflect the source Philips data or handling by other tools.
+Furthermore, in the real world there are many Philips DICOM images that ONLY contain IPP inside SQ 2005,140F. These situations appear to reflect modifications applied by a PACS to the DICOM data or attempts to anonymize the DICOM images (e.g. using simple Matlab scripts). Note that the private IPP differs from the public one by half a voxel. Therefore, in theory if one only has the private IPP, one can infer the public IPP location. Current versions of dcm2niix do not do this: the error is assumed small enough that it will not impact image processing steps such as coregistration.
+
+In general it is recommended that you archive and convert DICOM images as they are created from the scanner. If one does use an export tool such as the excellent dcmtk, it is recommended that you preserve the explicit VR, as implicit VR has the potential of obscuring private sequence (SQ) tags. Be aware that subsequent processing of DICOM data can disrupt data conversion.
 
 Therefore, dcm2niix will ignore the IPP enclosed in 2005,140F unless no alternative exists.
 
-## Derived Apparent Diffusion Coefficient maps stored with raw diffusion data
+## Derived parametric maps stored with raw diffusion data
 
-The DICOM standard requires derived data to be saved as a separate series number than the raw data. However, many Philips diffusion images append the derived ADC maps with the original data. Strangely, some of these ADC maps seem to be stored with specific diffusion directions, and with the same volume number as the B=0 image. In these cases, dcm2niix uses the Diffusion Directionality (0018,9075) tag to detect B=0 unweighted ("NONE"), B-weighted ("DIRECTIONAL"), and derived ("ISOTROPIC") images. Note that the Dimension Index Values (0020,9157) tag provides an alternative approach to discriminate these images. Here are sample tags from a Philips enhanced image that includes and ADC map (3rd dimension is "1" while the other images set this to "2").
+Some Philips diffusion DICOM images include derived image(s) along with the images. Other manufacturers save these derived images as a separate series number, and the DICOM standard seems ambiguous on whether it is allowable to mix raw and derived data in the same series (see PS 3.3-2008, C.7.6.1.1.2-3). In practice, many Philips diffusion images append [derived parametric maps](http://www.revisemri.com/blog/2008/diffusion-tensor-imaging/) with the original data. For example, ADC, Trace and Isotropic images can all be derived from the raw scans. As scientists, we want to discard these derived images, as they will disrupt data processing and we can generate better parametric maps after we have applied undistortion methods such as [Eddy and Topup](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy/UsersGuide). The current version of dcm2niix uses the Diffusion Directionality (0018,9075) tag to detect B=0 unweighted ("NONE"), B-weighted ("DIRECTIONAL"), and derived ("ISOTROPIC") images. Note that the Dimension Index Values (0020,9157) tag provides an alternative approach to discriminate these images. Here are sample tags from a Philips enhanced image that includes and derived map (3rd dimension is "1" while the other images set this to "2").
 
 ```
 (0018,9075) CS [DIRECTIONAL]
+(0018,9089) FD 1\0\0
+(0018,9087) FD 1000
 (0020,9157) UL 1\1\2\32
 ...
 (0018,9075) CS [ISOTROPIC]
+(0018,9087) FD 1000
 (0020,9157) UL 1\2\1\33
 ...
 (0018,9075) CS [NONE]
+(0018,9087) FD 0
 (0020,9157) UL 1\1\2\33
 ```
 
 ## Diffusion Direction
 
-Some Philips enhanced scans use tag 0018,9089 to report the 3 gradient directions. Other files use the tags 2005,10b0, 2005,10b1, 2005,10b2. In general, dcm2niix will use the values that most closely precede the Dimension Index Values (0020,9157).
+Proper Philips enhanced scans use tag 0018,9089 to report the 3 gradient directions. However, in the wild, other files from Philips (presumably using older versions of Philips software) use the tags 2005,10b0, 2005,10b1, 2005,10b2. In general, dcm2niix will use the values that most closely precede the Dimension Index Values (0020,9157).
+
+The current version of dcm2niix uses Dimension Index Values (0020,9157) to determine gradient number, which can also be found in (2005,1413). However, while 2005,1413 is always indexed from one, this is not necessarily the case for 0020,9157. For example, the ADNI DWI dataset for participant 018_S_4868 has values of 2005,1413 that range from 1..36 for the 36 directions, while 0020,9157 ranges from 2..37. The current version of dcm2niix compensates for this by re-indexing the values of 0020,9157 after all the volumes have been read.
 
 ## General variations
 
-The tags SliceNumberMrPhilips (2001,100A), NumberOfSlicesMrPhilips (2001,1018), and InStackPositionNumber (0020,9057) MRImageGradientOrientationNumber (2005,1413) are all potentially very useful for simplifying handling of enhanced DICOM images. However, none of these are reliably stored in all DICOM images. Therefore, dcm2niix does not depend on any of these, though it attempts to use several of these if they are available.
+Prior versions of dcm2niix used different methods to sort images. However, these have proved unreliable The undocumented tags SliceNumberMrPhilips (2001,100A), NumberOfSlicesMrPhilips (2001,1018) are not always present. In theory, InStackPositionNumber (0020,9057) should be present in all enhanced files, but has not proved reliable (perhaps not in older Philips images or DICOM images that were modified after leaving the scanner). MRImageGradientOrientationNumber (2005,1413) is complicated by the inclusion of derived images.Therefore, current versions of dcm2niix do not depend on any of these.

--- a/Philips/README.md
+++ b/Philips/README.md
@@ -1,0 +1,38 @@
+## About
+
+dcm2niix attempts to convert all DICOM images to NIfTI. The Philips enhanced DICOM images are elegantly able to save all images from a series as a single file. However, this format is necessarily complex. The usage of this format has evolved over time, and can become further complicated when DICOM are handled by DICOM tools (for example, anonymization, transfer which converts explicit VRs to implicit VRs, etc.).
+
+This web page describes some of the strategies handle these images. However, users should be vigilant when handling these datasets. If you encounter problems using dcm2niix you can explore [https://github.com/rordenlab/dcm2niix competing DICOM to NIfTI converters] or [ [https://github.com/rordenlab/dcm2niix report an issue].
+
+## Image Patient Position
+
+The Image Patient Position (0020,0032) tag is required to determine the position of the slices with respect to each other (and with respect to the scanner bore). Philips scans often report two conflicting IPPs for each single slice: with one stored in the private sequence (SQ) 2005,140F while the other is in the public sequence. This is unusual, but is [ftp://medical.nema.org/medical/dicom/final/cp758_ft.pdf legal].
+
+In practice, this complication has several major implications. First, not all software translate private SQs well. One potential problem is when the implicit VRs are saved as implicit VRs. This can obscure the fact that 2005,140F is an SQ. Indeed, some tools will convert the private SQ type as a "UN" unknown type and add another public sequence. This can confuse reading software.
+
+Furthermore, in the real world there are many Philips DICOM images that ONLY contain IPP inside SQ 2005,140F. It is not clear if this reflect the source Philips data or handling by other tools.
+
+Therefore, dcm2niix will ignore the IPP enclosed in 2005,140F unless no alternative exists.
+
+## Derived Apparent Diffusion Coefficient maps stored with raw diffusion data
+
+The DICOM standard requires derived data to be saved as a separate series number than the raw data. However, many Philips diffusion images append the derived ADC maps with the original data. Strangely, some of these ADC maps seem to be stored with specific diffusion directions, and with the same volume number as the B=0 image. In these cases, dcm2niix uses the Diffusion Directionality (0018,9075) tag to detect B=0 unweighted ("NONE"), B-weighted ("DIRECTIONAL"), and derived ("ISOTROPIC") images. Note that the Dimension Index Values (0020,9157) tag provides an alternative approach to discriminate these images. Here are sample tags from a Philips enhanced image that includes and ADC map (3rd dimension is "1" while the other images set this to "2").
+
+```
+(0018,9075) CS [DIRECTIONAL]
+(0020,9157) UL 1\1\2\32
+...
+(0018,9075) CS [ISOTROPIC]
+(0020,9157) UL 1\2\1\33
+...
+(0018,9075) CS [NONE]
+(0020,9157) UL 1\1\2\33
+```
+
+## Diffusion Direction
+
+Some Philips enhanced scans use tag 0018,9089 to report the 3 gradient directions. Other files use the tags 2005,10b0, 2005,10b1, 2005,10b2. In general, dcm2niix will use the values that most closely precede the Dimension Index Values (0020,9157).
+
+## General variations
+
+The tags SliceNumberMrPhilips (2001,100A), NumberOfSlicesMrPhilips (2001,1018), and InStackPositionNumber (0020,9057) MRImageGradientOrientationNumber (2005,1413) are all potentially very useful for simplifying handling of enhanced DICOM images. However, none of these are reliably stored in all DICOM images. Therefore, dcm2niix does not depend on any of these, though it attempts to use several of these if they are available.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ The batch processing binary `dcm2niibatch` is optional. To build `dcm2niibatch` 
 
 If you have any problems with the cmake build script described above or want to customize the software see the [COMPILE.md file for details on manual compilation](./COMPILE.md).
 
+## Alternatives
+
+ - [Valerio Luccio's dinifti](http://cbi.nyu.edu/software/dinifti.php) is focused on conversion of Siemens data
+ - [dcm2nii](http://www.mccauslandcenter.sc.edu/mricro/mricron/dcm2nii.htm) is the predecessor of dcm2niix. It is deprecated for modern images, but does handle image formats that predate DICOM (proprietary Elscint, GE and Siemens formats).
+ - [Xiangrui Li's dicm2nii](http://www.mathworks.com/matlabcentral/fileexchange/42997-dicom-to-nifti-converter) is written in Matlab. The Matlab language makes this very scriptable.
+ - [dicom2nifti](https://github.com/icometrix/dicom2nifti) uses the scriptable Python wrapper utilizes the [high performance  GDCMCONV](http://gdcm.sourceforge.net/wiki/index.php/Gdcmconv) executables.
+ - [MRtrix mrconvert](http://mrtrix.readthedocs.io/en/latest/reference/commands/mrconvert.html) is a useful general purpose image converter and handles DTI data well. It is an outstanding tool for modern Philips enhanced images.
+ - [Jolinda Smith's mcverter](http://lcni.uoregon.edu/%7Ejolinda/MRIConvert/) has great support for various vendors.
+ - [mri_convert](https://surfer.nmr.mgh.harvard.edu/pub/docs/html/mri_convert.help.xml.html) is part of the popular FreeSurfer package. In my limited experience this tool works well for GE and Siemens data, but fails with Philips 4D datasets.
+ - [SPM12](http://www.fil.ion.ucl.ac.uk/spm/software/spm12/) is one of the most popular tools in the field. It includes DICOM to NIfTI conversion. Being based on Matlab it is easy to script.
+
 ## Links
 
   - [Dcm2Bids](https://github.com/cbedetti/Dcm2Bids) uses dcm2niix to create [BIDS](http://bids.neuroimaging.io/) datasets.

--- a/README.md
+++ b/README.md
@@ -72,18 +72,19 @@ If you have any problems with the cmake build script described above or want to 
 
 ## Links
 
-  - [Dcm2Bids](https://github.com/cbedetti/Dcm2Bids) uses dcm2niix to create [BIDS](http://bids.neuroimaging.io/) datasets.
+  - [bidsify](https://github.com/spinoza-rec/bidsify) is a Python project that uses dcm2niix to convert DICOM and Philips PAR/REC images to the BIDS standard.
   - [bidskit](https://github.com/jmtyszka/bidskit) uses dcm2niix to create [BIDS](http://bids.neuroimaging.io/) datasets.
+  - [boutiques-dcm2niix](https://github.com/lalet/boutiques-dcm2niix) is a dockerfile for installing and validating dcm2niix.
   - [DAC2BIDS](https://github.com/dangom/dac2bids) uses dcm2niibatch to create [BIDS](http://bids.neuroimaging.io/) datasets.
+  - [Dcm2Bids](https://github.com/cbedetti/Dcm2Bids) uses dcm2niix to create [BIDS](http://bids.neuroimaging.io/) datasets.
+  - [dcm2niir](https://github.com/muschellij2/dcm2niir) R wrapper for dcm2niix/dcm2nii.
+  - [dcm2niix_afni](https://afni.nimh.nih.gov/pub/dist/doc/program_help/dcm2niix_afni.html) is a version of dcm2niix included with the [AFNI](https://afni.nimh.nih.gov/) distribution.
+  - [divest](https://github.com/jonclayden/divest) R interface to dcm2niix.
   - [heudiconv](https://github.com/nipy/heudiconv) can use dcm2niix to create [BIDS](http://bids.neuroimaging.io/) datasets.
+  - [MRIcroGL](https://github.com/neurolabusc/MRIcroGL) is available for MacOS, Linux and Windows and provides a graphical interface for dcm2niix. You can get compiled copies from the [MRIcroGL NITRC web site](https://www.nitrc.org/projects/mricrogl/).
+  - [neuro_docker](https://github.com/Neurita/neuro_docker) includes dcm2niix as part of a single, static Dockerfile.
+  - [NeuroDebian](http://neuro.debian.net/pkgs/dcm2niix.html) provides up-to-date version of dcm2niix for Debian-based systems.
+  - [neurodocker](https://github.com/kaczmarj/neurodocker) generates [custom](https://github.com/rordenlab/dcm2niix/issues/138) Dockerfiles given specific versions of neuroimaging software.
   - [nipype](https://github.com/nipy/nipype) can use dcm2niix to convert images.
   - [pydcm2niix is a Python module for working with dcm2niix](https://github.com/jstutters/pydcm2niix).
-  - [dcm2niir](https://github.com/muschellij2/dcm2niir) R wrapper for dcm2niix/dcm2nii.
-  - [divest](https://github.com/jonclayden/divest) R interface to dcm2niix.
   - [sci-tran dcm2niix](https://github.com/scitran-apps/dcm2niix) Flywheel Gear (docker).
-  - [neuro_docker](https://github.com/Neurita/neuro_docker) includes dcm2niix as part of a single, static Dockerfile.
-  - [boutiques-dcm2niix](https://github.com/lalet/boutiques-dcm2niix) is a dockerfile for installing and validating dcm2niix.
-  - [neurodocker](https://github.com/kaczmarj/neurodocker) generates [custom](https://github.com/rordenlab/dcm2niix/issues/138) Dockerfiles given specific versions of neuroimaging software.
-  - [dcm2niix_afni](https://afni.nimh.nih.gov/pub/dist/doc/program_help/dcm2niix_afni.html) is a version of dcm2niix included with the [AFNI](https://afni.nimh.nih.gov/) distribution.
-  - [MRIcroGL](https://github.com/neurolabusc/MRIcroGL) is available for MacOS, Linux and Windows and provides a graphical interface for dcm2niix. You can get compiled copies from the [MRIcroGL NITRC web site](https://www.nitrc.org/projects/mricrogl/).
-  - [NeuroDebian](http://neuro.debian.net/pkgs/dcm2niix.html) provides up-to-date version of dcm2niix for Debian-based systems.

--- a/console/main_console.cpp
+++ b/console/main_console.cpp
@@ -326,7 +326,7 @@ int main(int argc, const char * argv[])
                     opts.isVerbose = 0;
                 else if ((argv[i][0] == 'o') || (argv[i][0] == 'O')) {//-1: experimental SQ skipping: 'O'ptimized!? faster, does not get confused with Philips tags
                     opts.isVerbose = -1;
-                    printf(">>Experimental SQ skipping enabled\n");
+                    printf(">> Experimental SQ skipping enabled\n");
 
                 } else if ((argv[i][0] == 'h') || (argv[i][0] == 'H')  || (argv[i][0] == '2')) //2: verbose HYPER
                     opts.isVerbose = 2;

--- a/console/main_console.cpp
+++ b/console/main_console.cpp
@@ -324,7 +324,11 @@ int main(int argc, const char * argv[])
                 if (invalidParam(i, argv)) return 0;
                 if ((argv[i][0] == 'n') || (argv[i][0] == 'N')  || (argv[i][0] == '0')) //0: verbose OFF
                     opts.isVerbose = 0;
-                else if ((argv[i][0] == 'h') || (argv[i][0] == 'H')  || (argv[i][0] == '2')) //2: verbose HYPER
+                else if ((argv[i][0] == 'o') || (argv[i][0] == 'O')) {//-1: experimental SQ skipping: 'O'ptimized!? faster, does not get confused with Philips tags
+                    opts.isVerbose = -1;
+                    printf(">>Experimental SQ skipping enabled\n");
+
+                } else if ((argv[i][0] == 'h') || (argv[i][0] == 'H')  || (argv[i][0] == '2')) //2: verbose HYPER
                     opts.isVerbose = 2;
                 else
                     opts.isVerbose = 1; //1: verbose ON

--- a/console/main_console.cpp
+++ b/console/main_console.cpp
@@ -360,7 +360,7 @@ int main(int argc, const char * argv[])
                 strcpy(opts.outdir,argv[i]);
             } else if ((argv[i][1] == 'n') && ((i+1) < argc)) {
               i++;
-              int seriesNumber = atoi(argv[i]);
+              float seriesNumber = atof(argv[i]);
               if (seriesNumber < 0)
               	opts.numSeries = -1; //report series: convert none
               else if ((opts.numSeries >= 0) && (opts.numSeries < MAX_NUM_SERIES)) {

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -2932,6 +2932,7 @@ void _update_tvd(struct TVolumeDiffusion* ptvd) {
 
 struct TDICOMdata readDICOMv(char * fname, int isVerbose, int compressFlag, struct TDTI4D *dti4D) {
 	struct TDICOMdata d = clear_dicom_data();
+	d.imageNum = 0; //not set
     strcpy(d.protocolName, ""); //erase dummy with empty
     strcpy(d.protocolName, ""); //erase dummy with empty
     strcpy(d.seriesDescription, ""); //erase dummy with empty
@@ -3574,8 +3575,7 @@ uint32_t kUnnest2 = 0xFFFE +(0xE0DD << 16 ); //#define  kUnnest2 0xFFFE +(0xE0DD
                 d.acquNum = dcmStrInt(lLength, &buffer[lPos]);
                 break;
             case kImageNum:
-                //int dx = 3;
-                if (d.imageNum <= 1) d.imageNum = dcmStrInt(lLength, &buffer[lPos]);  //Philips renames each image as image1 in 2001,9000
+                if (d.imageNum < 1) d.imageNum = dcmStrInt(lLength, &buffer[lPos]);  //Philips renames each image again in 2001,9000, which can lead to duplicates
                 break;
             case kDimensionIndexValues:  // kImageNum is not enough for 4D series from Philips 5.*.
               {                                   // { necessary for initializing ndim.
@@ -4168,6 +4168,10 @@ uint32_t kUnnest2 = 0xFFFE +(0xE0DD << 16 ); //#define  kUnnest2 0xFFFE +(0xE0DD
     if (d.CSA.numDti >= kMaxDTI4D) {
         printError("Unable to convert DTI [recompile with increased kMaxDTI4D] detected=%d, max = %d\n", d.CSA.numDti, kMaxDTI4D);
         d.CSA.numDti = 0;
+    }
+    if (d.imageNum == 0) {
+    	printError("Image number (0020,0013) not found.\n");
+        d.imageNum = 1; //not set
     }
     if (multiBandFactor > d.CSA.multiBandFactor)
     	d.CSA.multiBandFactor = multiBandFactor; //SMS reported in 0051,1011 but not CSA header

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -719,6 +719,8 @@ struct TDICOMdata clear_dicom_data() {
     d.echoTrainLength = 0;
     d.phaseFieldofView = 0.0;
     d.dwellTime = 0;
+    d.protocolBlockStartGE = 0;
+    d.protocolBlockLengthGE = 0;
     d.phaseEncodingSteps = 0;
     d.coilNum = 0;
     d.accelFactPE = 0.0;
@@ -3444,7 +3446,7 @@ double TE = 0.0; //most recent echo time recorded
     uint32_t groupElement;
     long lPos = 0;
     bool isPhilipsDerived = false;
-    bool isPhilipsDiffusion = false;
+    //bool isPhilipsDiffusion = false;
     if (isPart10prefix) { //for part 10 files, skip preamble and prefix
     	lPos = 128+4; //4-byte signature starts at 128
     	groupElement = buffer[lPos] | (buffer[lPos+1] << 8) | (buffer[lPos+2] << 16) | (buffer[lPos+3] << 24);
@@ -4072,8 +4074,9 @@ double TE = 0.0; //most recent echo time recorded
                 break;
             case kProtocolDataBlockGE :
             	if (d.manufacturer != kMANUFACTURER_GE) break;
-            	//printError("ProtocolDataBlockGE to do  %d %d %2x%2x\n", lPos, lLength, (uint8_t)buffer[lPos], (uint8_t)buffer[lPos+1]);
-            	//readProtocolDataBlockGE(&buffer[lPos], lLength, &d.CSA, isVerbose); //, dti4D);
+            	d.protocolBlockLengthGE = dcmInt(lLength,&buffer[lPos],d.isLittleEndian);
+            	d.protocolBlockStartGE = lPos+lFileOffset+4;
+            	//printError("ProtocolDataBlockGE %d  @ %d\n", d.protocolBlockLengthGE, d.protocolBlockStartGE);
             	break;
             case kDoseCalibrationFactor :
                 d.doseCalibrationFactor = dcmStrFloat(lLength, &buffer[lPos]);

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -3500,7 +3500,6 @@ double TE = 0.0; //most recent echo time recorded
                 	encapsulatedDataFragmentStart = (int)lPos + (int)lFileOffset;
             }
         }
-        if ((isIconImageSequence) && ((groupElement & 0x0028) == 0x0028 )) groupElement = kUnused; //ignore icon dimensions
         if ((sqEndPrivate > 0) && ((lFileOffset + lPos) > sqEndPrivate))
         	sqEndPrivate = -1; //end of private SQ with defined length
         if (groupElement == kSequenceDelimitationItemTag) { //end of private SQ with undefined length
@@ -3509,8 +3508,8 @@ double TE = 0.0; //most recent echo time recorded
         		sqDepthPrivate = 0; //no longer in a private SQ
         	}
         }
-
         if (sqDepth < 0) sqDepth = 0;*/
+        if ((isIconImageSequence) && ((groupElement & 0x0028) == 0x0028 )) groupElement = kUnused; //ignore icon dimensions
         if (groupElement == kSequenceDelimitationItemTag) is2005140FSQ = false;
         switch ( groupElement ) {
             case kTransferSyntax: {

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -1752,7 +1752,8 @@ struct TDICOMdata  nii_readParRec (char * parname, int isVerbose, struct TDTI4D 
     }
     //even is sequential, we need to decode if multiple echoes/phasemaps,etc
     //if (!isSlicesSpatiallySequentialPhilips) {
-    	printWarning("PAR file order of slices is not sequential: please ensure correct slice re-ordering\n");
+    	//printWarning("PAR file order of slices is not sequential: please ensure correct slice re-ordering\n");
+    	d.isScaleOrTEVaries = true;
     	if (numSlice2D > kMaxSlice2D) {
     		printError("Overloaded slice re-ordering. Number of slices (%d) exceeds kMaxSlice2D (%d)\n", numSlice2D, kMaxSlice2D);
     		dti4D->sliceOrder[0] = -1;
@@ -1893,8 +1894,6 @@ struct TDICOMdata  nii_readParRec (char * parname, int isVerbose, struct TDTI4D 
 		}
 		if (d.isScaleOrTEVaries)
 			printWarning("Varying dimensions (echoes, phase maps, intensity scaling) will require volumes to be saved separately (hint: you may prefer dicm2nii output)\n");
-
-
     }
     //check DTI makes sense
     if (d.CSA.numDti > 1) {
@@ -1909,7 +1908,8 @@ struct TDICOMdata  nii_readParRec (char * parname, int isVerbose, struct TDTI4D 
     	if ((!v1varies) || (!v2varies) || (!v3varies))
     		 printError("Bizarre b-vectors %s\n", parname);
     }
-    if ((maxEcho > 1) || (maxCardiac > 1)) printWarning("Multiple Echo (%d) or Cardiac (%d). Segment output, e.g. nii_segment4d('img.nii', %d)\n", maxEcho,  maxCardiac, maxEcho*maxCardiac);
+    if ((maxEcho > 1) || (maxCardiac > 1)) printWarning("Multiple Echo (%d) or Cardiac (%d). Carefully inspect output\n", maxEcho,  maxCardiac);
+    if ((maxEcho > 1) || (maxCardiac > 1)) d.isScaleOrTEVaries = true;
     return d;
 } //nii_readParRec()
 

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -3509,6 +3509,15 @@ double TE = 0.0; //most recent echo time recorded
         	}
         }
         if (sqDepth < 0) sqDepth = 0;*/
+        if ((groupElement == kItemTag)  && (isEncapsulatedData)) {
+            d.imageBytes = dcmInt(4,&buffer[lPos-4],d.isLittleEndian);
+            //printMessage("compressed data %d-> %ld\n",d.imageBytes, lPos);
+            if (d.imageBytes > 128) {
+            	encapsulatedDataFragments++;
+   				if (encapsulatedDataFragmentStart == 0)
+                	encapsulatedDataFragmentStart = (int)lPos + (int)lFileOffset;
+            }
+        }
         if ((isIconImageSequence) && ((groupElement & 0x0028) == 0x0028 )) groupElement = kUnused; //ignore icon dimensions
         if (groupElement == kSequenceDelimitationItemTag) is2005140FSQ = false;
         switch ( groupElement ) {

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -631,7 +631,7 @@ int headerDcm2Nii2(struct TDICOMdata d, struct TDICOMdata d2, struct nifti_1_hea
     }
     snprintf(h->descrip,80, "%s",txt);
     if (strlen(d.imageComments) > 0)
-        snprintf(h->aux_file,24,"%s",d.imageComments);
+        snprintf(h->aux_file,24,"%.23s",d.imageComments);
     return headerDcm2NiiSForm(d,d2, h, isVerbose);
 } //headerDcm2Nii2()
 

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -38,7 +38,7 @@ extern "C" {
 	#define kCCsuf " CompilerNA" //unknown compiler!
 #endif
 
-#define kDCMvers "v1.0.20171215" kDCMsuf kCCsuf
+#define kDCMvers "v1.0.20180303" kDCMsuf kCCsuf
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -38,7 +38,7 @@ extern "C" {
 	#define kCCsuf " CompilerNA" //unknown compiler!
 #endif
 
-#define kDCMvers "v1.0.20180303" kDCMsuf kCCsuf
+#define kDCMvers "v1.0.20180304" kDCMsuf kCCsuf
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -118,8 +118,8 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
     struct TDICOMdata {
         long seriesNum;
         int xyzDim[5];
-        int modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, echoTrainLength, patientPositionNumPhilips, coilNum, echoNum, sliceOrient,numberOfDynamicScans, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,patientPositionSequentialRepeats,locationsInAcquisition, compressionScheme;
-        float patientWeight, zSpacing, zThick, pixelBandwidth, SAR, phaseFieldofView, accelFactPE, flipAngle, fieldStrength, TE, TI, TR, intenScale, intenIntercept, intenScalePhilips, gantryTilt, lastScanLoc, angulation[4];
+        int modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, echoTrainLength, patientPositionNumPhilips, coilNum, echoNum, sliceOrient,numberOfDynamicScans, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,patientPositionSequentialRepeats,patientPositionRepeats,locationsInAcquisition, compressionScheme;
+        float patientWeight, zSpacing, zThick, pixelBandwidth, SAR, phaseFieldofView, accelFactPE, flipAngle, fieldStrength, TE, TE2, TI, TR, intenScale, intenIntercept, intenScalePhilips, gantryTilt, lastScanLoc, angulation[4];
         float orient[7], patientPosition[4], patientPositionLast[4], xyzMM[4], stackOffcentre[4];
         float radionuclidePositronFraction, radionuclideTotalDose, radionuclideHalfLife, doseCalibrationFactor; //PET ISOTOPE MODULE ATTRIBUTES (C.8-57)
 		float ecat_isotope_halflife, ecat_dosage;
@@ -129,11 +129,12 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
         char imageComments[kDICOMStrLarge];
         uint32_t dimensionIndexValues[MAX_NUMBER_OF_DIMENSIONS];
         struct TCSAdata CSA;
-        bool isSegamiOasis, isDerived, isXRay, isMultiEcho, isSlicesSpatiallySequentialPhilips, isValid, is3DAcq, is2DAcq, isExplicitVR, isLittleEndian, isPlanarRGB, isSigned, isHasPhase,isHasMagnitude,isHasMixed, isFloat, isResampled;
+        bool isSegamiOasis, isDerived, isXRay, isMultiEcho, isSlicesSpatiallySequentialPhilips, isValid, is3DAcq, is2DAcq, isExplicitVR, isLittleEndian, isPlanarRGB, isSigned, isHasPhase,isHasMagnitude,isHasMixed, isFloat, isResampled, isLocalizer;
         char phaseEncodingRC, patientSex;
     };
 
     size_t nii_ImgBytes(struct nifti_1_header hdr);
+    int isSameFloatGE (float a, float b);
     struct TDICOMdata readDICOMv(char * fname, int isVerbose, int compressFlag, struct TDTI4D *dti4D);
     struct TDICOMdata readDICOM(char * fname);
     struct TDICOMdata clear_dicom_data();

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -77,6 +77,7 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
     struct TDTI {
         float V[4];
         int sliceNumberMrPhilips;
+        int sliceNumberMrPhilipsVol2;
     };
     struct TDTI4D {
         struct TDTI S[kMaxDTI4D];

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -38,7 +38,7 @@ extern "C" {
 	#define kCCsuf " CompilerNA" //unknown compiler!
 #endif
 
-#define kDCMvers "v1.0.20180305" kDCMsuf kCCsuf
+#define kDCMvers "v1.0.20180306" kDCMsuf kCCsuf
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -38,7 +38,7 @@ extern "C" {
 	#define kCCsuf " CompilerNA" //unknown compiler!
 #endif
 
-#define kDCMvers "v1.0.20180307" kDCMsuf kCCsuf
+#define kDCMvers "v1.0.20180325" kDCMsuf kCCsuf
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images
@@ -127,7 +127,7 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
         //numberOfDynamicScans, patientPositionNumPhilips
         //patientPositionSequentialRepeats,patientPositionRepeats,
         //maxGradDynVol, gradDynVol,
-        int modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, echoTrainLength, coilNum, echoNum, sliceOrient, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,locationsInAcquisition, compressionScheme;
+        int protocolBlockStartGE, protocolBlockLengthGE, modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, echoTrainLength, coilNum, echoNum, sliceOrient, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,locationsInAcquisition, compressionScheme;
         float patientWeight, zSpacing, zThick, pixelBandwidth, SAR, phaseFieldofView, accelFactPE, flipAngle, fieldStrength, TE, TI, TR, intenScale, intenIntercept, intenScalePhilips, gantryTilt, lastScanLoc, angulation[4];
         float orient[7], patientPosition[4], patientPositionLast[4], xyzMM[4], stackOffcentre[4];
         float radionuclidePositronFraction, radionuclideTotalDose, radionuclideHalfLife, doseCalibrationFactor; //PET ISOTOPE MODULE ATTRIBUTES (C.8-57)

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -38,7 +38,7 @@ extern "C" {
 	#define kCCsuf " CompilerNA" //unknown compiler!
 #endif
 
-#define kDCMvers "v1.0.20180306" kDCMsuf kCCsuf
+#define kDCMvers "v1.0.20180307" kDCMsuf kCCsuf
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images
@@ -83,6 +83,7 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
     struct TDTI4D {
         struct TDTI S[kMaxDTI4D];
         int sliceOrder[kMaxSlice2D]; // [7,3,2] means the first slice on disk should be moved to 7th position
+        int gradDynVol[kMaxDTI4D]; //used to parse dimensions of Philips data, e.g. file with multiple dynamics, echoes, phase+magnitude
         float TE[kMaxDTI4D], intenScale[kMaxDTI4D], intenIntercept[kMaxDTI4D], intenScalePhilips[kMaxDTI4D];
         bool isPhase[kMaxDTI4D];
     };
@@ -125,6 +126,7 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
         int xyzDim[5];
         //numberOfDynamicScans, patientPositionNumPhilips
         //patientPositionSequentialRepeats,patientPositionRepeats,
+        //maxGradDynVol, gradDynVol,
         int modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, echoTrainLength, coilNum, echoNum, sliceOrient, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,locationsInAcquisition, compressionScheme;
         float patientWeight, zSpacing, zThick, pixelBandwidth, SAR, phaseFieldofView, accelFactPE, flipAngle, fieldStrength, TE, TI, TR, intenScale, intenIntercept, intenScalePhilips, gantryTilt, lastScanLoc, angulation[4];
         float orient[7], patientPosition[4], patientPositionLast[4], xyzMM[4], stackOffcentre[4];
@@ -147,7 +149,7 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
     struct TDICOMdata readDICOMv(char * fname, int isVerbose, int compressFlag, struct TDTI4D *dti4D);
     struct TDICOMdata readDICOM(char * fname);
     struct TDICOMdata clear_dicom_data();
-    struct TDICOMdata  nii_readParRec (char * parname, int isVerbose, struct TDTI4D *dti4D);
+    struct TDICOMdata  nii_readParRec (char * parname, int isVerbose, struct TDTI4D *dti4D, bool isReadPhase);
     unsigned char * nii_flipY(unsigned char* bImg, struct nifti_1_header *h);
     unsigned char * nii_flipZ(unsigned char* bImg, struct nifti_1_header *h);
     //*unsigned char * nii_reorderSlices(unsigned char* bImg, struct nifti_1_header *h, struct TDTI4D *dti4D);

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -42,7 +42,7 @@ extern "C" {
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images
-static const int kMaxSlice2D = 16786; //maximum number of 2D slices in 4D (Philips) images
+static const int kMaxSlice2D = 64000; //maximum number of 2D slices in 4D (Philips) images
 
 #define kDICOMStr 64
 #define kDICOMStrLarge 256

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -38,7 +38,7 @@ extern "C" {
 	#define kCCsuf " CompilerNA" //unknown compiler!
 #endif
 
-#define kDCMvers "v1.0.20180304" kDCMsuf kCCsuf
+#define kDCMvers "v1.0.20180305" kDCMsuf kCCsuf
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -42,6 +42,8 @@ extern "C" {
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic
 static const int kMaxDTI4D = 4096; //maximum number of DTI directions for 4D (Philips) images, also maximum number of 3D slices for Philips 3D and 4D images
+static const int kMaxSlice2D = 16786; //maximum number of 2D slices in 4D (Philips) images
+
 #define kDICOMStr 64
 #define kDICOMStrLarge 256
 #define kMANUFACTURER_UNKNOWN  0
@@ -76,11 +78,13 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
 
     struct TDTI {
         float V[4];
-        int sliceNumberMrPhilips;
-        int sliceNumberMrPhilipsVol2;
+        //int totalSlicesIn4DOrder;
     };
     struct TDTI4D {
         struct TDTI S[kMaxDTI4D];
+        int sliceOrder[kMaxSlice2D]; // [7,3,2] means the first slice on disk should be moved to 7th position
+        float TE[kMaxDTI4D], intenScale[kMaxDTI4D], intenIntercept[kMaxDTI4D], intenScalePhilips[kMaxDTI4D];
+        bool isPhase[kMaxDTI4D];
     };
 
 #ifdef _MSC_VER //Microsoft nomenclature for packed structures is different...
@@ -111,15 +115,18 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
     } TCSAitem; //Siemens csa item structure
 #endif
     struct TCSAdata {
-    	bool isPhaseMap;
-        float sliceTiming[kMaxEPI3D], dtiV[4], sliceNormV[4], bandwidthPerPixelPhaseEncode, sliceMeasurementDuration;
+    	float sliceTiming[kMaxEPI3D], dtiV[4], sliceNormV[4], bandwidthPerPixelPhaseEncode, sliceMeasurementDuration;
         int numDti, SeriesHeader_offset, SeriesHeader_length, multiBandFactor, sliceOrder, slice_start, slice_end, mosaicSlices,protocolSliceNumber1,phaseEncodingDirectionPositive;
+    	bool isPhaseMap;
+
     };
     struct TDICOMdata {
         long seriesNum;
         int xyzDim[5];
-        int modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, echoTrainLength, patientPositionNumPhilips, coilNum, echoNum, sliceOrient,numberOfDynamicScans, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,patientPositionSequentialRepeats,patientPositionRepeats,locationsInAcquisition, compressionScheme;
-        float patientWeight, zSpacing, zThick, pixelBandwidth, SAR, phaseFieldofView, accelFactPE, flipAngle, fieldStrength, TE, TE2, TI, TR, intenScale, intenIntercept, intenScalePhilips, gantryTilt, lastScanLoc, angulation[4];
+        //numberOfDynamicScans, patientPositionNumPhilips
+        //patientPositionSequentialRepeats,patientPositionRepeats,
+        int modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, echoTrainLength, coilNum, echoNum, sliceOrient, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,locationsInAcquisition, compressionScheme;
+        float patientWeight, zSpacing, zThick, pixelBandwidth, SAR, phaseFieldofView, accelFactPE, flipAngle, fieldStrength, TE, TI, TR, intenScale, intenIntercept, intenScalePhilips, gantryTilt, lastScanLoc, angulation[4];
         float orient[7], patientPosition[4], patientPositionLast[4], xyzMM[4], stackOffcentre[4];
         float radionuclidePositronFraction, radionuclideTotalDose, radionuclideHalfLife, doseCalibrationFactor; //PET ISOTOPE MODULE ATTRIBUTES (C.8-57)
 		float ecat_isotope_halflife, ecat_dosage;
@@ -129,8 +136,10 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
         char imageComments[kDICOMStrLarge];
         uint32_t dimensionIndexValues[MAX_NUMBER_OF_DIMENSIONS];
         struct TCSAdata CSA;
-        bool isSegamiOasis, isDerived, isXRay, isMultiEcho, isSlicesSpatiallySequentialPhilips, isValid, is3DAcq, is2DAcq, isExplicitVR, isLittleEndian, isPlanarRGB, isSigned, isHasPhase,isHasMagnitude,isHasMixed, isFloat, isResampled, isLocalizer;
+        //isSlicesSpatiallySequentialPhilips
+        bool isSegamiOasis, isScaleOrTEVaries,  isDerived, isXRay, isMultiEcho, isValid, is3DAcq, is2DAcq, isExplicitVR, isLittleEndian, isPlanarRGB, isSigned, isHasPhase,isHasMagnitude,isHasMixed, isFloat, isResampled, isLocalizer;
         char phaseEncodingRC, patientSex;
+        //uint32_t *totalSlicesIn4DOrder; //Reordering array for Philips slices
     };
 
     size_t nii_ImgBytes(struct nifti_1_header hdr);
@@ -141,14 +150,14 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
     struct TDICOMdata  nii_readParRec (char * parname, int isVerbose, struct TDTI4D *dti4D);
     unsigned char * nii_flipY(unsigned char* bImg, struct nifti_1_header *h);
     unsigned char * nii_flipZ(unsigned char* bImg, struct nifti_1_header *h);
-    unsigned char * nii_reorderSlices(unsigned char* bImg, struct nifti_1_header *h, struct TDTI4D *dti4D);
+    //*unsigned char * nii_reorderSlices(unsigned char* bImg, struct nifti_1_header *h, struct TDTI4D *dti4D);
     void changeExt (char *file_name, const char* ext);
     unsigned char * nii_planar2rgb(unsigned char* bImg, struct nifti_1_header *hdr, int isPlanar);
 	int isDICOMfile(const char * fname); //0=not DICOM, 1=DICOM, 2=NOTSURE(not part 10 compliant)
     void setQSForm(struct nifti_1_header *h, mat44 Q44i, bool isVerbose);
     int headerDcm2Nii2(struct TDICOMdata d, struct TDICOMdata d2, struct nifti_1_header *h, int isVerbose);
     int headerDcm2Nii(struct TDICOMdata d, struct nifti_1_header *h, bool isComputeSForm) ;
-    unsigned char * nii_loadImgXL(char* imgname, struct nifti_1_header *hdr, struct TDICOMdata dcm, bool iVaries, int compressFlag, int isVerbose);
+    unsigned char * nii_loadImgXL(char* imgname, struct nifti_1_header *hdr, struct TDICOMdata dcm, bool iVaries, int compressFlag, int isVerbose, struct TDTI4D *dti4D);
 #ifdef  __cplusplus
 }
 #endif

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2500,7 +2500,10 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dc
     for(int i = 0; i < nConvert; ++i)
       dcmList[dcmSort[i].indx].converted2NII = 1;
     if (opts.numSeries < 0) { //report series number but do not convert
-    	printMessage("\t%ld\t%s\n", dcmList[dcmSort[0].indx].seriesNum, pathoutname);
+    	if (vol >= 0)
+    		printMessage("\t%ld.%d\t%s\n", dcmList[dcmSort[0].indx].seriesNum, vol, pathoutname);
+    	else
+    		printMessage("\t%ld\t%s\n", dcmList[dcmSort[0].indx].seriesNum, pathoutname);
     	printMessage(" %s\n",nameList->str[dcmSort[0].indx]);
     	return EXIT_SUCCESS;
     }
@@ -2521,8 +2524,12 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dc
     // skip converting if user has specified one or more series, but has not specified this one
     if (opts.numSeries > 0) {
       int i = 0;
+      float seriesNum = (float) dcmList[dcmSort[0].indx].seriesNum;
+      if (vol > 0)
+      	seriesNum = seriesNum + (float) vol / 10.0; //n.b. we will have problems if vol > 9. However, 9 distinct TEs/scalings/PhaseMag seems unlikely
       for (; i < opts.numSeries; i++) {
-        if (opts.seriesNumber[i] == dcmList[dcmSort[0].indx].seriesNum) {
+        if (isSameFloatGE(opts.seriesNumber[i], seriesNum)) {
+        //if (opts.seriesNumber[i] == dcmList[dcmSort[0].indx].seriesNum) {
           break;
         }
       }

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2656,9 +2656,8 @@ int saveDcm2Nii(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dcmLis
 		return EXIT_FAILURE;
 	}
     int ret = EXIT_SUCCESS;
-
 	//check for repeated echoes - count unique number of echoes
-	/* //code below checks for multi-echoes - not required if maxNumberOfEchoes reported in PARREC
+	//code below checks for multi-echoes - not required if maxNumberOfEchoes reported in PARREC
 	int echoNum[kMaxDTI4D];
 	int echo = 1;
 	for (int i = 0; i < dcmList[indx].xyzDim[4]; i++)
@@ -2672,7 +2671,7 @@ int saveDcm2Nii(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dcmLis
 			echoNum[i] = echo;
 		}
 	}
-	if (echo > 1) dcmList[indx].isMultiEcho = true;*/
+	if (echo > 1) dcmList[indx].isMultiEcho = true;
 	//check for repeated volumes
 	int seriesNum[kMaxDTI4D];
 	int series = 1;
@@ -2687,7 +2686,6 @@ int saveDcm2Nii(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dcmLis
 			seriesNum[i] = series;
 		}
 	}
-
 	for (int s = 1; s <= series; s++) {
 		for (int i = 0; i < dcmList[indx].xyzDim[4]; i++)
 			dti4D->gradDynVol[i] = 0;

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -28,7 +28,8 @@ extern "C" {
         bool isSave3D,isGz, isFlipY,  isCreateBIDS, isSortDTIbyBVal, isAnonymizeBIDS, isOnlyBIDS, isCreateText, isIgnoreDerivedAnd2D, isPhilipsFloatNotDisplayScaling, isTiltCorrect, isRGBplanar, isOnlySingleFile, isForceStackSameSeries, isCrop;
         int isVerbose, compressFlag, gzLevel; //support for compressed data 0=none,
         char filename[512], outdir[512], indir[512], pigzname[512], optsname[512], indirParent[512], imageComments[24];
-        long seriesNumber[MAX_NUM_SERIES], numSeries;
+        float seriesNumber[MAX_NUM_SERIES];
+        long numSeries;
 #ifdef HAVE_R
         bool isScanOnly;
         void *imageList;


### PR DESCRIPTION
- [Improved Philips PAR/REC support](https://github.com/rordenlab/dcm2niix/issues/171)
- [Improved Philips Enhanced DICOM support](https://github.com/rordenlab/dcm2niix/issues/170)
- [Improved GE support](https://github.com/rordenlab/dcm2niix/issues/163)
  - Uses proprietary GE Protocol Data Block (0025,101B).
  - Assumes raw text - reports exist of a [xml variant](https://groups.google.com/forum/#!msg/comp.protocols.dicom/mxnCkv8A-i4/W_uc6SxLwHQJ) 
 - Slice timing mimics dicm2nii. Assumes continuous acquisition (e.g. we do not know how to detect GE sparse acquisitions) and single-band (we do not know how to detect GE multi-band).
 

