### PR TITLE
Use PkgConfig to find yaml-cpp

### DIFF
--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -160,7 +160,11 @@ if(BATCH_VERSION)
 
     set(YAML-CPP_DIR ${YAML-CPP_DIR} CACHE PATH "Path to yaml-cpp configuration file" FORCE)
 
-    find_package(YAML-CPP REQUIRED)
+    # PkgConfig way found to provide more robust detection of yaml-cpp on older
+    # Debian/Ubuntu releases
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
+
     target_include_directories(dcm2niibatch PRIVATE ${YAML_CPP_INCLUDE_DIR})
     target_link_libraries(dcm2niibatch ${YAML_CPP_LIBRARIES})
 


### PR DESCRIPTION
Seems to resolve problem finding yaml-cpp on older (~jessie)
systems.  Solution was picked up from
https://answers.ros.org/question/262502/cmake-cant-find-yaml-cpp-on-debian-jessie/

Origin: NeuroDebian
Last-Update: 2018-06-14

Feel free to ignore -- just wanted to let you consider it.  It did help me out