### PR TITLE
Proposed fix for #222

### DIFF
--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -4458,6 +4458,12 @@ double TE = 0.0; //most recent echo time recorded
             	dcmStr(lLength, &buffer[lPos], d.referringPhysicianName);
             	break;
             case kComplexImageComponent:
+                // Disabling kComplexImageComponent because sometimes it is
+                // wrong, possibly due to munging by XNAT. dcm2niix will also
+                // get the complex image component from (0008, 0008) ImageType,
+                // but since this, (0008, 9208), comes later, it would override
+                // ImageType.
+                break; 
                 if (is2005140FSQ) break; //see Maastricht DICOM data for magnitude data with this field set as REAL!  https://www.nitrc.org/plugins/mwiki/index.php/dcm2nii:MainPage#Diffusion_Tensor_Imaging
                 if (lLength < 2) break;
                 isPhase = false;
@@ -5195,7 +5201,8 @@ double TE = 0.0; //most recent echo time recorded
       				int check =dcmInt(2,(unsigned char*)hdr + epi_chk_off,true) & 0x800;
      				if (check == 0) {
 						if (isVerboseX > 1) printMessage("%s: Warning: Data is not EPI\n", fname);
-						continue;
+					 	//continue;
+                                                break;
       				}
     			}
             	//Check for PE polarity

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -4458,12 +4458,12 @@ double TE = 0.0; //most recent echo time recorded
             	dcmStr(lLength, &buffer[lPos], d.referringPhysicianName);
             	break;
             case kComplexImageComponent:
-                // Disabling kComplexImageComponent because sometimes it is
-                // wrong, possibly due to munging by XNAT. dcm2niix will also
-                // get the complex image component from (0008, 0008) ImageType,
-                // but since this, (0008, 9208), comes later, it would override
-                // ImageType.
-                break; 
+                // // Disabling kComplexImageComponent because sometimes it is
+                // // wrong, possibly due to munging by XNAT. dcm2niix will also
+                // // get the complex image component from (0008, 0008) ImageType,
+                // // but since this, (0008, 9208), comes later, it would override
+                // // ImageType.
+                // break; 
                 if (is2005140FSQ) break; //see Maastricht DICOM data for magnitude data with this field set as REAL!  https://www.nitrc.org/plugins/mwiki/index.php/dcm2nii:MainPage#Diffusion_Tensor_Imaging
                 if (lLength < 2) break;
                 isPhase = false;


### PR DESCRIPTION
This is to ensure that the pixel data of nonEPI GE slices gets read. The branch is misnamed because I started the day looking at why _real sometimes pops up in magnitude file names.
