### PR TITLE
Changes from divest, up to version 0.6.1

### DIFF
--- a/console/nifti1_io_core.cpp
+++ b/console/nifti1_io_core.cpp
@@ -31,7 +31,7 @@
 
 #include "print.h"
 
-#ifndef HAVE_R
+#ifndef USING_R
 void nifti_swap_8bytes( size_t n , void *ar )    // 4 bytes at a time
 {
     size_t ii ;
@@ -192,7 +192,7 @@ mat44 nifti_dicom2mat(float orient[7], float patientPosition[4], float xyzMM[4])
     return Q44;
 }
 
-#ifndef HAVE_R
+#ifndef USING_R
 float nifti_mat33_determ( mat33 R )   /* determinant of 3x3 matrix */
 {
     double r11,r12,r13,r21,r22,r23,r31,r32,r33 ;
@@ -239,7 +239,7 @@ mat33 nifti_mat33_transpose( mat33 A )  /* transpose 3x3 matrix */
     return B;
 }
 
-#ifndef HAVE_R
+#ifndef USING_R
 mat33 nifti_mat33_inverse( mat33 R )   /* inverse of 3x3 matrix */
 {
     double r11,r12,r13,r21,r22,r23,r31,r32,r33 , deti ;

--- a/console/nifti1_io_core.h
+++ b/console/nifti1_io_core.h
@@ -4,7 +4,7 @@
 #ifndef _NIFTI_IO_CORE_HEADER_
 #define _NIFTI_IO_CORE_HEADER_
 
-#ifdef HAVE_R
+#ifdef USING_R
 #define STRICT_R_HEADERS
 #include "RNifti.h"
 #endif
@@ -17,7 +17,7 @@ extern "C" {
 
 #include <string.h>
 
-#ifndef HAVE_R
+#ifndef USING_R
 typedef struct {                   /** 4x4 matrix struct **/
     float m[3][3] ;
 } mat33 ;

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "nifti1_io_core.h"
-#ifndef HAVE_R
+#ifndef USING_R
 #include "nifti1.h"
 #endif
 

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -29,7 +29,7 @@
 #include "tinydir.h"
 #include "print.h"
 #include "nifti1_io_core.h"
-#ifndef HAVE_R
+#ifndef USING_R
 #include "nifti1.h"
 #endif
 #include "nii_dicom_batch.h"
@@ -64,7 +64,7 @@
 	const char kFileSep[2] = "/";
 #endif
 
-#ifdef HAVE_R
+#ifdef USING_R
 #include "ImageList.h"
 
 #undef isnan
@@ -1427,7 +1427,7 @@ int * nii_SaveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],str
         } //for each direction
     }
     //printMessage("%f\t%f\t%f",dcmList[indx0].CSA.dtiV[1][1],dcmList[indx0].CSA.dtiV[1][2],dcmList[indx0].CSA.dtiV[1][3]);
-#ifdef HAVE_R
+#ifdef USING_R
     std::vector<double> bValues(numDti);
     std::vector<double> bVectors(numDti*3);
     for (int i = 0; i < numDti; i++)
@@ -1968,7 +1968,7 @@ void writeNiiGz (char * baseName, struct nifti_1_header hdr,  unsigned char* src
 } //writeNiiGz()
 #endif
 
-#ifdef HAVE_R
+#ifdef USING_R
 
 // Version of nii_saveNII() for R/divest: create nifti_image pointer and push onto stack
 int nii_saveNII (char *niiFilename, struct nifti_1_header hdr, unsigned char *im, struct TDCMopts opts)
@@ -3027,10 +3027,11 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dc
     for(int i = 0; i < nConvert; ++i)
       dcmList[dcmSort[i].indx].converted2NII = 1;
     if (opts.numSeries < 0) { //report series number but do not convert
-    	if (segVol >= 0)
+    	if (segVol >= 0) {
     		printMessage("\t%ld.%d\t%s\n", dcmList[dcmSort[0].indx].seriesNum, segVol-1, pathoutname);
-    	else
+    	} else {
     		printMessage("\t%ld\t%s\n", dcmList[dcmSort[0].indx].seriesNum, pathoutname);
+        }
     	printMessage(" %s\n",nameList->str[dcmSort[0].indx]);
     	return EXIT_SUCCESS;
     }
@@ -3091,7 +3092,7 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dc
     //~ 	nii_reorderSlices(imgM, &hdr0, dti4D);
     if (hdr0.dim[3] < 2)
     	printWarning("Check that 2D images are not mirrored.\n");
-#ifndef HAVE_R
+#ifndef USING_R
     else
         fflush(stdout); //GUI buffers printf, display all results
 #endif
@@ -3112,7 +3113,7 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dc
     else {
         if (volOrderIndex) //reorder volumes
         	imgM = reorderVolumes(&hdr0, imgM, volOrderIndex);
-#ifndef HAVE_R
+#ifndef USING_R
 		if ((opts.isIgnoreDerivedAnd2D) && (numADC > 0))
 			printMessage("Ignoring derived diffusion image(s). Better isotropic and ADC maps can be generated later processing.\n");
 		if ((!opts.isIgnoreDerivedAnd2D) && (numADC > 0)) {//ADC maps can disrupt analysis: save a copy with the ADC map, and another without
@@ -3126,7 +3127,7 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dc
 		}
 #endif
 		imgM = removeADC(&hdr0, imgM, numADC);
-#ifndef HAVE_R
+#ifndef USING_R
 		if (opts.isSave3D)
 			returnCode = nii_saveNII3D(pathoutname, hdr0, imgM, opts);
 		else
@@ -3153,7 +3154,7 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[],struct TDICOMdata dc
     }
     if ((opts.isCrop) && (dcmList[indx0].is3DAcq)   && (hdr0.dim[3] > 1) && (hdr0.dim[0] < 4))//for T1 scan: && (dcmList[indx0].TE < 25)
         returnCode = nii_saveCrop(pathoutname, hdr0, imgM,opts); //n.b. must be run AFTER nii_setOrtho()!
-#ifdef HAVE_R
+#ifdef USING_R
     // Note that for R, only one image should be created per series
     // Hence the logical OR here
     if (returnCode == EXIT_SUCCESS || nii_saveNII(pathoutname,hdr0,imgM,opts) == EXIT_SUCCESS)
@@ -3757,7 +3758,7 @@ int nii_loadDir(struct TDCMopts* opts) {
     if (opts->isRenameNotConvert > 0) {
     	return EXIT_SUCCESS;
     }
-#ifdef HAVE_R
+#ifdef USING_R
     if (opts->isScanOnly) {
         TWarnings warnings = setWarnings();
         // Create the first series from the first DICOM file
@@ -3830,7 +3831,7 @@ int nii_loadDir(struct TDCMopts* opts) {
 			free(dcmSort);
 		}//convert all images of this series
     }
-#ifdef HAVE_R
+#ifdef USING_R
     }
 #endif
     free(dcmList);
@@ -3868,8 +3869,8 @@ int nii_loadDir(struct TDCMopts* opts) {
     strcpy(name,""); //not found!
 }*/
 
-#if defined(_WIN64) || defined(_WIN32)
-#else //UNIX
+#if defined(_WIN64) || defined(_WIN32) || defined(USING_R)
+#else //UNIX, not R
 
 int findpathof(char *pth, const char *exe) {
 //Find executable by searching the PATH environment variable.
@@ -3914,6 +3915,7 @@ int findpathof(char *pth, const char *exe) {
 }
 #endif
 
+#ifndef USING_R
 void readFindPigz (struct TDCMopts *opts, const char * argv[]) {
     #if defined(_WIN64) || defined(_WIN32)
     strcpy(opts->pigzname,"pigz.exe");
@@ -3998,6 +4000,7 @@ void readFindPigz (struct TDCMopts *opts, const char * argv[]) {
 	//printMessage("Found pigz: %s\n", str);
     #endif
 } //readFindPigz()
+#endif
 
 void setDefaultOpts (struct TDCMopts *opts, const char * argv[]) { //either "setDefaultOpts(opts,NULL)" or "setDefaultOpts(opts,argv)" where argv[0] is path to search
     strcpy(opts->pigzname,"");

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -10,12 +10,12 @@ extern "C" {
 
 #include <stdbool.h> //requires VS 2015 or later
 #include <string.h>
-#ifndef HAVE_R
+#ifndef USING_R
 #include "nifti1.h"
 #endif
 #include "nii_dicom.h"
 
-#ifdef HAVE_R
+#ifdef USING_R
     struct TDicomSeries {
         TDICOMdata representativeData;
         std::vector<std::string> files;
@@ -30,7 +30,7 @@ extern "C" {
         char filename[512], outdir[512], indir[512], pigzname[512], optsname[512], indirParent[512], imageComments[24];
         float seriesNumber[MAX_NUM_SERIES];
         long numSeries;
-#ifdef HAVE_R
+#ifdef USING_R
         bool isScanOnly;
         void *imageList;
         std::vector<TDicomSeries> series;

--- a/console/nii_ortho.cpp
+++ b/console/nii_ortho.cpp
@@ -1,4 +1,4 @@
-#ifndef HAVE_R
+#ifndef USING_R
 #include "nifti1.h"
 #endif
 #include "nifti1_io_core.h"

--- a/console/nii_ortho.h
+++ b/console/nii_ortho.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
     
-#ifndef HAVE_R
+#ifndef USING_R
 #include "nifti1.h"
 #endif
     

--- a/console/print.h
+++ b/console/print.h
@@ -8,7 +8,7 @@
 #ifndef _R_PRINT_H_
 	#define _R_PRINT_H_
 	#include <stdarg.h>
-	#ifdef HAVE_R
+	#ifdef USING_R
 		#define R_USE_C99_IN_CXX
 		#include <R_ext/Print.h>
 		#define printMessage(...) { Rprintf("[dcm2niix info] "); Rprintf(__VA_ARGS__); }
@@ -48,5 +48,5 @@
 		// #define printError(...) ({ printMessage("Error: "); printMessage(__VA_ARGS__);})
 		#define printWarning(...) do {printMessage("Warning: "); printMessage(__VA_ARGS__);} while(0)
 
-	#endif //HAVE_R
+	#endif //USING_R
 #endif //_R_PRINT_H_


### PR DESCRIPTION
Some unobtrusive changes from across recent versions of `divest`, so as to keep the two code-bases in line: a change in the fencing marker for R (`HAVE_R` -> `USING_R`, since the latter is defined by R itself), and some adjustments to work around compiler and `valgrind` warnings – the latter due to a fairly heavy stack allocation, which I avoid.

I think the continuous integration is currently failing on the `master` branch of `dcm2niix`, so it will fail here too, but I don't see any additional failures [on Travis](https://travis-ci.org/jonclayden/divest/jobs/429532537).