### PR TITLE
Slice timing (divest)

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2759,14 +2759,14 @@ void nii_saveAttributes (struct TDICOMdata &data, struct nifti_1_header &header,
             images->addAttribute("phaseEncodingSign", data.CSA.phaseEncodingDirectionPositive == 0 ? -1 : 1);
         }
     }
-    // Slice timing
+    
+    // Slice timing (stored in seconds)
     if (data.CSA.sliceTiming[0] >= 0.0 && (data.manufacturer == kMANUFACTURER_UIH || data.manufacturer == kMANUFACTURER_GE || (data.manufacturer == kMANUFACTURER_SIEMENS && !data.isXA10A))) {
         std::vector<double> sliceTimes;
-        #pragma message ("Please test R specific code: at this stage all slice times should be in msec due to changes in checkSliceTiming() 20190704")
-        for (int i=header.dim[3]-1; i>=0; i--) {
-        	if (data.CSA.sliceTiming[i] < 0.0)
-            	break;
-            sliceTimes.push_back(data.CSA.sliceTiming[i]); //slice time in msec
+        for (int i=0; i<header.dim[3]; i++) {
+            if (data.CSA.sliceTiming[i] < 0.0)
+                break;
+            sliceTimes.push_back(data.CSA.sliceTiming[i] / 1000.0);
         }
         images->addAttribute("sliceTiming", sliceTimes);
     }

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -4276,6 +4276,7 @@ void rescueSliceTimingSiemens(struct TDICOMdata * d, int verbose, int nSL, const
 	if (d->CSA.sliceTiming[0] >= 0.0) return; //slice times calculated
 	if (nSL < 2) return;
 	if ((d->manufacturer != kMANUFACTURER_SIEMENS) || (d->CSA.SeriesHeader_offset < 1) || (d->CSA.SeriesHeader_length < 1)) return;
+#ifdef myReadAsciiCsa
 	float shimSetting[8];
 	char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrLarge];
 	TCsaAscii csaAscii;
@@ -4315,6 +4316,7 @@ void rescueSliceTimingSiemens(struct TDICOMdata * d, int verbose, int nSL, const
 	} //if ucMode == 3 int
 	//dicm2nii provides sSliceArray.ucImageNumb - similar to protocolSliceNumber1
 	//if asc_header(s, 'sSliceArray.ucImageNumb'), t = t(nSL:-1:1); end % rev-num
+#endif
 }
 
 void sliceTimingUIH(struct TDCMsort *dcmSort,struct TDICOMdata *dcmList, struct nifti_1_header * hdr, int verbose, const char * filename, int nConvert) {


### PR DESCRIPTION
Sorry to miss your release with this, but I’ve now tested the updated slice timing code and made the necessary modifications to get it working correctly with `divest`. I’ve also added an extra `myReadAsciiCsa` fence to get the code to compile without that flag set – I assume this would be needed for `dcm2niix` builds too.