### PR TITLE
Changes from divest 0.9

### DIFF
--- a/console/nifti1_io_core.cpp
+++ b/console/nifti1_io_core.cpp
@@ -17,7 +17,6 @@
 
 #include <stdbool.h> //requires VS 2015 or later
 #include "nifti1_io_core.h"
-#include "nifti1.h"
 #include <math.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -80,7 +79,6 @@ void nifti_swap_2bytes( size_t n , void *ar )    // 2 bytes at a time
     }
     return ;
 }
-#endif
 
 /*-------------------------------------------------------------------------*/
 /*! Byte swap NIFTI-1 file header in various places and ways.
@@ -137,6 +135,7 @@ void swap_nifti_header( struct nifti_1_header *h  )
 
    return ;
 }
+#endif
 
 bool littleEndianPlatform ()
 {

--- a/console/nifti1_io_core.h
+++ b/console/nifti1_io_core.h
@@ -6,11 +6,12 @@
 
 #ifdef USING_R
 #define STRICT_R_HEADERS
+#include <stdint.h>
 #include "RNifti.h"
 #else
 #include "nifti1.h"
-#endif
 #include <stdint.h>
+#endif
 
 #ifdef  __cplusplus
 extern "C" {

--- a/console/nifti1_io_core.h
+++ b/console/nifti1_io_core.h
@@ -7,8 +7,9 @@
 #ifdef USING_R
 #define STRICT_R_HEADERS
 #include "RNifti.h"
-#endif
+#else
 #include "nifti1.h"
+#endif
 #include <stdint.h>
 
 #ifdef  __cplusplus
@@ -70,7 +71,10 @@ vec3 nifti_vect33mat33_mul(vec3 v, mat33 m );
 ivec3 setiVec3(int x, int y, int z);
 vec3 setVec3(float x, float y, float z);
 vec4 setVec4(float x, float y, float z);
+#ifndef USING_R
+// This declaration differs from the equivalent function in the current nifti1_io.h, so avoid the clash
 void  swap_nifti_header ( struct nifti_1_header *h) ;
+#endif
 vec4 nifti_vect44mat44_mul(vec4 v, mat44 m );
 void nifti_swap_2bytes( size_t n , void *ar );    // 2 bytes at a time
 void nifti_swap_4bytes( size_t n , void *ar );    // 4 bytes at a time

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -6951,9 +6951,8 @@ if (d.isHasPhase)
 	}
 	if ((isDICOMANON) && (isMATLAB)) {
 		//issue 383
-		d.seriesInstanceUID[0] = '\0';
-		strcat(d.seriesInstanceUID, d.studyDate);
-		strcat(d.seriesInstanceUID, d.studyTime);
+		strcpy(d.seriesInstanceUID, d.studyDate);
+		strncat(d.seriesInstanceUID, d.studyTime, kDICOMStr-strlen(d.studyDate));
 		d.seriesUidCrc = mz_crc32X((unsigned char*) &d.seriesInstanceUID, strlen(d.seriesInstanceUID));
 	}
     if ((d.manufacturer == kMANUFACTURER_SIEMENS) && (strstr(d.sequenceName, "_fl2d1") != NULL)) {

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -6952,7 +6952,10 @@ if (d.isHasPhase)
 	if ((isDICOMANON) && (isMATLAB)) {
 		//issue 383
 		strcpy(d.seriesInstanceUID, d.studyDate);
-		strncat(d.seriesInstanceUID, d.studyTime, kDICOMStr-strlen(d.studyDate));
+        // This check is unlikely to be important in practice, but it silences a warning from GCC with -Wrestrict
+        if (strlen(d.studyDate) < kDICOMStr) {
+    		strncat(d.seriesInstanceUID, d.studyTime, kDICOMStr-strlen(d.studyDate));
+        }
 		d.seriesUidCrc = mz_crc32X((unsigned char*) &d.seriesInstanceUID, strlen(d.seriesInstanceUID));
 	}
     if ((d.manufacturer == kMANUFACTURER_SIEMENS) && (strstr(d.sequenceName, "_fl2d1") != NULL)) {

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2815,38 +2815,21 @@ void nii_saveAttributes (struct TDICOMdata &data, struct nifti_1_header &header,
 {
     ImageList *images = (ImageList *) opts.imageList;
     switch (data.modality) {
-        case kMODALITY_CR:
-            images->addAttribute("modality", "CR");
-            break;
-        case kMODALITY_CT:
-            images->addAttribute("modality", "CT");
-            break;
-        case kMODALITY_MR:
-            images->addAttribute("modality", "MR");
-            break;
-        case kMODALITY_PT:
-            images->addAttribute("modality", "PT");
-            break;
-        case kMODALITY_US:
-            images->addAttribute("modality", "US");
-            break;
+        case kMODALITY_CR: images->addAttribute("modality", "CR"); break;
+        case kMODALITY_CT: images->addAttribute("modality", "CT"); break;
+        case kMODALITY_MR: images->addAttribute("modality", "MR"); break;
+        case kMODALITY_PT: images->addAttribute("modality", "PT"); break;
+        case kMODALITY_US: images->addAttribute("modality", "US"); break;
     }
     switch (data.manufacturer) {
-        case kMANUFACTURER_SIEMENS:
-        	images->addAttribute("manufacturer", "Siemens");
-        	break;
-        case kMANUFACTURER_GE:
-        	images->addAttribute("manufacturer", "GE");
-        	break;
-        case kMANUFACTURER_PHILIPS:
-        	images->addAttribute("manufacturer", "Philips");
-        	break;
-        case kMANUFACTURER_TOSHIBA:
-        	images->addAttribute("manufacturer", "Toshiba");
-        	break;
-        case kMANUFACTURER_Canon:
-        	images->addAttribute("manufacturer", "Canon");
-        	break;
+        case kMANUFACTURER_SIEMENS: images->addAttribute("manufacturer", "Siemens"); break;
+        case kMANUFACTURER_GE:      images->addAttribute("manufacturer", "GE");      break;
+        case kMANUFACTURER_PHILIPS: images->addAttribute("manufacturer", "Philips"); break;
+        case kMANUFACTURER_TOSHIBA: images->addAttribute("manufacturer", "Toshiba"); break;
+        case kMANUFACTURER_UIH:     images->addAttribute("manufacturer", "UIH");     break;
+        case kMANUFACTURER_BRUKER:  images->addAttribute("manufacturer", "Bruker");  break;
+        case kMANUFACTURER_HITACHI: images->addAttribute("manufacturer", "Hitachi"); break;
+        case kMANUFACTURER_CANON:   images->addAttribute("manufacturer", "Canon");   break;
     }
     if (strlen(data.manufacturersModelName) > 0)
         images->addAttribute("scannerModelName", data.manufacturersModelName);

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2879,7 +2879,7 @@ void nii_saveAttributes (struct TDICOMdata &data, struct nifti_1_header &header,
     // See the nii_SaveBIDS() function for details
     int reconMatrixPE = data.phaseEncodingLines;
     if ((header.dim[2] > 0) && (header.dim[1] > 0)) {
-        if (header.dim[2] == header.dim[2]) //phase encoding does not matter
+        if (header.dim[1] == header.dim[2]) //phase encoding does not matter
             reconMatrixPE = header.dim[2];
         else if (data.phaseEncodingRC =='C')
             reconMatrixPE = header.dim[2];

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -1685,8 +1685,8 @@ int * nii_saveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],str
     uint64_t indx0 = dcmSort[0].indx; //first volume
     int numDti = dcmList[indx0].CSA.numDti;
 #ifdef USING_R
-	//R might want to pad zeros
-#else    
+    ImageList *images = (ImageList *) opts.imageList;
+#endif
     //https://github.com/rordenlab/dcm2niix/issues/352
     bool allB0 = dcmList[indx0].isDiffusion;
     if (dcmList[indx0].isDerived) allB0 = false; //e.g. FA map
@@ -1697,6 +1697,11 @@ int * nii_saveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],str
     if (allB0) {
     	if (opts.isVerbose)
 			printMessage("Diffusion image without gradients: assuming %d volume B=0 series\n", numVol);
+#ifdef USING_R
+		// The image hasn't been created yet, so the attributes must be deferred
+		images->addDeferredAttribute("bValues", std::vector<double>(numVol,0.0));
+		images->addDeferredAttribute("bVectors", std::vector<double>(numVol*3,0.0), numVol, 3);
+#else
 	    char sep = '\t';
 		if (opts.isCreateBIDS)
             sep = ' ';
@@ -1719,8 +1724,8 @@ int * nii_saveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],str
 			fprintf(fp, "\n");
 		}
 		fclose(fp);
+#endif
     } 
-#endif    
     if (numDti < 1) return NULL;
     if ((numDti < 3) && (nConvert < 3)) return NULL;
     TDTI * vx = NULL;
@@ -1940,7 +1945,6 @@ int * nii_saveDTI(char pathoutname[],int nConvert, struct TDCMsort dcmSort[],str
             bVectors[i+j*numDti] = vx[i].V[j+1];
     }
     // The image hasn't been created yet, so the attributes must be deferred
-    ImageList *images = (ImageList *) opts.imageList;
     images->addDeferredAttribute("bValues", bValues);
     images->addDeferredAttribute("bVectors", bVectors, numDti, 3);
 #else

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2877,9 +2877,9 @@ void nii_saveAttributes (struct TDICOMdata &data, struct nifti_1_header &header,
     if ((header.dim[2] > 0) && (header.dim[1] > 0)) {
         if (header.dim[2] == header.dim[2]) //phase encoding does not matter
             reconMatrixPE = header.dim[2];
-        else if (data.phaseEncodingRC =='R')
-            reconMatrixPE = header.dim[2];
         else if (data.phaseEncodingRC =='C')
+            reconMatrixPE = header.dim[2];
+        else if (data.phaseEncodingRC =='R')
             reconMatrixPE = header.dim[1];
     }
 

--- a/console/tinydir.h
+++ b/console/tinydir.h
@@ -347,7 +347,9 @@ int tinydir_readfile(const tinydir_dir *dir, tinydir_file *file)
 		dir->_e->d_name
 #endif
 	);
-	strcat(file->path, file->name);
+    /* Limit the number of bytes copied to the maximum length of the name,
+    to avoid spurious compiler warnings about possible overlap */
+	strncat(file->path, file->name, _TINYDIR_FILENAME_MAX);
 #ifndef _MSC_VER
 	if (stat(file->path, &file->_s) == -1)
 	{


### PR DESCRIPTION
This covers the changes to the core code made for `divest`, up to version 0.9.0, rebased onto the `development` branch. They mostly fix some compile-time issues, including warnings from certain compilers, and get the R codepaths to match the main ones when handling diffusion acquisitions with b=0 throughout.