### PR TITLE
Remove redundant underscores before creating subdirectories

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2714,6 +2714,18 @@ int nii_createFilename(struct TDICOMdata dcm, char * niiFilename, struct TDCMopt
     appendChar[0] = kPathSeparator;
     if ((strlen(pth) > 0) && (pth[strlen(pth)-1] != kPathSeparator) && (outname[0] != kPathSeparator))
         strcat (baseoutname,appendChar);
+    
+    //remove redundant underscores
+    int len = strlen(outname);
+    int outpos = 0;
+    for (int inpos = 0; inpos < len; inpos ++) {
+        if ((outpos > 0) && (outname[inpos] == '_') && (outname[outpos-1] == '_'))
+            continue;
+        outname[outpos] = outname[inpos];
+        outpos++;
+    }
+    outname[outpos] = 0;
+    
 	//Allow user to specify new folders, e.g. "-f dir/%p" or "-f %s/%p/%m"
 	// These folders are created if they do not exist
     char *sep = strchr(outname, kPathSeparator);
@@ -2741,16 +2753,6 @@ int nii_createFilename(struct TDICOMdata dcm, char * niiFilename, struct TDCMopt
     		strcat (newdir,ch);
     	}
     }
-    //remove redundant underscores
-    int len = strlen(outname);
-    int outpos = 0;
-    for (int inpos = 0; inpos < len; inpos ++) {
-        if ((outpos > 0) && (outname[inpos] == '_') && (outname[outpos-1] == '_'))
-        	continue;
-        outname[outpos] = outname[inpos];
-        outpos++;	
-	}
-	outname[outpos] = 0;
 	//printMessage("path='%s' name='%s'\n", pathoutname, outname);
     //make sure outname is unique
     strcat (baseoutname,outname);


### PR DESCRIPTION
The code introduced in commit d88da85 to (once again) collapse underscores in filenames seems to appear too late in the logic of the function, if subdirectories need to be created. In this case the uncollapsed directory name will be created, resulting in a subsequent failure to create files within the directory with the collapsed name, since it hasn't been created.

I've moved this logic slightly earlier in the function to resolve the issue. This seems to work correctly in my limited testing, but I may have missed some possible code-paths so it's worth double-checking the new placement.