### PR TITLE
Adds a script to extract units from BIDS/README.md into json

### DIFF
--- a/BIDS/extract_units.py
+++ b/BIDS/extract_units.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+"""extract_units.py - extract BIDS/README.md's units as json
+
+Usage:
+  extract_units.py [-e EXISTING -o OUT] [MD]
+  extract_units.py (-h|--help|--version)
+
+Arguments:
+  MD:      A Markdown input file including tables with Field and Unit as the
+           first two columns.
+           [default: README.md]
+
+Options:
+  -h --help                      Show this message and exit.
+  --version                      Show version and exit.
+  -e EXISTING --ex=EXISTING     Extract units for all the fields, and only the
+                                 fields in EXISTING, a BIDS file,
+                                 and write the output to
+                                 EXISTING.replace('.json', '_units.json')
+                                 instead of stdout.
+  -o OUT --out=OUT              If given, save the output to this filename.
+                                 (Overrides the implicit destination of -e.)
+"""
+from __future__ import print_function
+try:
+    import json_tricks as json
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        # Not really compatible with json_tricks because it does not support
+        # primitives=True
+        import json
+import sys
+
+# Please use semantic versioning (API.feature.bugfix), http://semver.org/
+__version__ = '0.0.0'
+
+
+def extract_units(mdfn):
+    units = {}
+    intable = False
+    with open(mdfn) as md:
+        for line in md:
+            if line.startswith('|'):
+                parts = [s.strip() for s in line.split('|')[1:-1]]
+                if parts[:2] == ['Field', 'Unit']:
+                    intable = True
+                elif intable and parts[1] and not parts[1].startswith('-'):
+                    units[parts[0]] = parts[1]
+            else:
+                intable = False
+    return units
+
+
+def main(mdfn, existing=None, outfn=None):
+    units = extract_units(mdfn)
+    if existing:
+        with open(existing) as f:  # Can't count on having json_tricks.
+            used = json.load(f)
+        units = {k: v for k, v in units.items() if k in used}
+        if not outfn:
+            outfn = existing.replace('.json', '_units.json')
+    outtext = json.dumps(units, indent=2, sort_keys=True,
+                         separators=(', ', ': '))
+    if outfn:
+        with open(outfn, 'w') as outf:
+            outf.write(outtext + "\n")
+    else:
+        print(outtext)
+    return units
+
+
+if __name__ == '__main__':
+    from docopt import docopt
+
+    args = docopt(__doc__, version=__version__)
+    #print(args)
+
+    # https://github.com/docopt/docopt/issues/214 has been open for
+    # almost 7 years, so it looks like docopt isn't getting default
+    # positional args.
+    output = main(args['MD'] or 'README.md',
+                  args.get('--ex'), args.get('--out'))
+    sys.exit(0)


### PR DESCRIPTION
Hi,

Following through on issue #516, my lab will need to get the units for the BIDS sidecars in json format, a la the ..._units.json file mentioned in the BIDS standard. I think it is best to minimize the number of places where the units for the BIDS fields are maintained, so I wish to contribute this script that reads the | Field | Unit | ... |  tables in BIDS/README.md and outputs JSON.

If run on README.md with no options it prints out the fields and units of all the fields with units.

If also given the -e option and an existing BIDS sidecar (say, BIDS_sidecar.json), it filters down to the fields in the sidecar that have units, and writes to BIDS_sidecar_units.json. This is the form we would use to get the units for a BIDS sidecar.

I realize that strictly speaking this would add a dependency on python and the modules the script uses (namely docopt), but I see it more as contributed script for those who want it than a necessary dependency.

Rob 