### PR TITLE
dcm2niix_fswrapper class

### DIFF
--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -206,4 +206,19 @@ if(APPLE)
     # launchctl plist ./dcm2niix
 endif()
 
+### start of addition for FREESURFER
+set(DCM2NIIXFSLIB dcm2niixfs)
+add_library(${DCM2NIIXFSLIB} STATIC
+    dcm2niix_fswrapper.cpp
+    nii_dicom.cpp
+    jpg_0XC3.cpp
+    ujpeg.cpp
+    nifti1_io_core.cpp
+    nii_foreign.cpp
+    nii_ortho.cpp
+    nii_dicom_batch.cpp)
+target_compile_definitions(${DCM2NIIXFSLIB} PUBLIC -DUSING_DCM2NIIXFSWRAPPER -DUSING_MGH_NIFTI_IO)
+### end of addition for FREESURFER
+
 install(TARGETS ${PROGRAMS} DESTINATION bin)
+

--- a/console/dcm2niix_fswrapper.cpp
+++ b/console/dcm2niix_fswrapper.cpp
@@ -1,0 +1,121 @@
+#include <stdio.h>
+
+#include "nii_dicom.h"
+#include "dcm2niix_fswrapper.h"
+
+struct TDCMopts dcm2niix_fswrapper::tdcmOpts;
+
+/* These are the TDCMopts defaults set in dcm2niix
+isIgnoreTriggerTimes = false
+isTestx0021x105E = false
+isAddNamePostFixes = true
+isSaveNativeEndian = true
+isOneDirAtATime = false
+isRenameNotConvert = false
+isSave3D = false
+isGz = false
+isPipedGz = false
+isFlipY = true
+isCreateBIDS = true
+isSortDTIbyBVal = false
+isAnonymizeBIDS = true
+isOnlyBIDS = false
+isCreateText = false
+isForceOnsetTimes = true
+isIgnoreDerivedAnd2D = false
+isPhilipsFloatNotDisplayScaling = true
+isTiltCorrect = true
+isRGBplanar = false
+isOnlySingleFile = false
+isForceStackDCE = true
+isIgnoreSeriesInstanceUID = false    // if true, d.seriesUidCrc = d.seriesNum;
+isRotate3DAcq = true
+isCrop = false
+saveFormat = 0
+isMaximize16BitRange = 2
+isForceStackSameSeries = 2
+nameConflictBehavior = 2
+isVerbose = 0
+isProgress = 0
+compressFlag = 0
+dirSearchDepth = 5
+gzLevel = 6
+filename = "%s_%p"    // seriesNum_protocol -f "%s_%p"
+outdir = "..."
+indir = "..."
+pigzname = '\000'
+optsname = "~/.dcm2nii.ini"
+indirParent = "..."
+imageComments = ""
+seriesNumber = nnn 
+numSeries = 0
+ */
+
+// set TDCMopts defaults, overwrite settings to output in mgz orientation
+void dcm2niix_fswrapper::setOpts(const char* dcmindir, const char* niioutdir)
+{
+  memset(&tdcmOpts, 0, sizeof(tdcmOpts));
+  setDefaultOpts(&tdcmOpts, NULL);
+
+  if (dcmindir != NULL)
+    strcpy(tdcmOpts.indir, dcmindir);
+  if (niioutdir != NULL)
+    strcpy(tdcmOpts.outdir, niioutdir);
+
+  // set the options for freesurfer mgz orientation
+  tdcmOpts.isRotate3DAcq = false;
+  tdcmOpts.isFlipY = false;
+  tdcmOpts.isIgnoreSeriesInstanceUID = true;
+  tdcmOpts.isCreateBIDS = false;
+  tdcmOpts.isGz = false;
+  //tdcmOpts.isForceStackSameSeries = 1; // merge 2D slice '-m y'
+  tdcmOpts.isForceStackDCE = false;
+  //tdcmOpts.isForceOnsetTimes = false;
+}
+
+// interface to isDICOMfile() in nii_dicom.cpp
+bool dcm2niix_fswrapper::isDICOM(const char* file)
+{
+  return isDICOMfile(file);
+}
+
+/*
+ * interface to nii_loadDirCore() to search all dicom files from the directory input file is in,
+ * and convert dicom files with the same series as given file.
+ */
+int dcm2niix_fswrapper::dcm2NiiOneSeries(const char* dcmfile)
+{
+  // get seriesNo for given dicom file
+  struct TDICOMdata tdicomData = readDICOM((char*)dcmfile);
+
+  double seriesNo = (double)tdicomData.seriesUidCrc;
+  if (tdcmOpts.isIgnoreSeriesInstanceUID)
+    seriesNo = (double)tdicomData.seriesNum;
+
+  // set TDCMopts to convert just one series
+  tdcmOpts.seriesNumber[0] = seriesNo;
+  tdcmOpts.numSeries = 1;
+
+  return nii_loadDirCore(tdcmOpts.indir, &tdcmOpts);
+}
+
+// interface to nii_getMrifsStruct()
+MRIFSSTRUCT* dcm2niix_fswrapper::getMrifsStruct(void)
+{
+  return nii_getMrifsStruct();
+}
+
+// return nifti header saved in MRIFSSTRUCT
+nifti_1_header* dcm2niix_fswrapper::getNiiHeader(void)
+{
+  MRIFSSTRUCT* mrifsStruct = getMrifsStruct();
+  return &mrifsStruct->hdr0;
+}
+
+// return image data saved in MRIFSSTRUCT
+const unsigned char* dcm2niix_fswrapper::getMRIimg(void)
+{
+  MRIFSSTRUCT* mrifsStruct = getMrifsStruct();
+  return mrifsStruct->imgM;
+}
+

--- a/console/dcm2niix_fswrapper.h
+++ b/console/dcm2niix_fswrapper.h
@@ -1,0 +1,42 @@
+#ifndef DCM2NIIX_FSWRAPPER_H
+#define DCM2NIIX_FSWRAPPER_H
+
+#include "nii_dicom_batch.h"
+#include "nii_dicom.h"
+
+/*
+ * This is a wrapper class to interface with dcm2niix functions.
+ * 1. The wrapper class provides interface to convert dicom in mgz orientation.
+ * 2. The wrapper class and dcm2niix functions are compiled into libdcm2niixfs.a 
+ *    with -DUSING_DCM2NIIXFSWRAPPER -DUSING_MGH_NIFTI_IO.
+ * 3. When using libdcm2niixfs.a, instead of outputting .nii, *.bval, *.bvec to disk, 
+ *    nifti header, image data, TDICOMdata, & TDTI information are saved in MRIFSSTRUCT struct.
+ * 4. If libdcm2niixfs.a is compiled with -DUSING_MGH_NIFTI_IO, the application needs to link with nifti library.
+ */
+class dcm2niix_fswrapper
+{
+public:
+  // set TDCMopts defaults, overwrite settings to output in mgz orientation.
+  static void setOpts(const char* dcmindir, const char* niioutdir);
+
+  // interface to isDICOMfile() in nii_dicom.cpp
+  static bool isDICOM(const char* file);
+
+  // interface to nii_loadDirCore() to search all dicom files from the directory input file is in,
+  // and convert dicom files with the same series as given file.
+  static int dcm2NiiOneSeries(const char* dcmfile);
+
+  // interface to nii_getMrifsStruct()
+  static MRIFSSTRUCT* getMrifsStruct(void);
+
+  // return nifti header saved in MRIFSSTRUCT 
+  static nifti_1_header* getNiiHeader(void);
+
+  // return image data saved in MRIFSSTRUCT
+  static const unsigned char* getMRIimg(void);
+
+private:
+  static struct TDCMopts tdcmOpts;
+};
+
+#endif

--- a/console/nifti1_io_core.cpp
+++ b/console/nifti1_io_core.cpp
@@ -33,6 +33,7 @@
 
 
 #ifndef USING_R
+#ifndef USING_MGH_NIFTI_IO
 void nifti_swap_8bytes( size_t n , void *ar )    // 4 bytes at a time
 {
     size_t ii ;
@@ -86,7 +87,7 @@ void nifti_swap_2bytes( size_t n , void *ar )    // 2 bytes at a time
     If is_nifti, swap all (even UNUSED) fields of NIfTI header.
     Else, swap as a nifti_analyze75 struct.
 *//*---------------------------------------------------------------------- */
-void swap_nifti_header( struct nifti_1_header *h  )
+void swap_nifti_header( struct nifti_1_header *h )
 {
 
    /* otherwise, swap all NIFTI fields */
@@ -135,6 +136,7 @@ void swap_nifti_header( struct nifti_1_header *h  )
 
    return ;
 }
+#endif
 #endif
 
 bool littleEndianPlatform ()
@@ -268,6 +270,7 @@ mat44 nifti_dicom2mat(float orient[7], float patientPosition[4], float xyzMM[4])
 }
 
 #ifndef USING_R
+#ifndef USING_MGH_NIFTI_IO
 float nifti_mat33_determ( mat33 R )   /* determinant of 3x3 matrix */
 {
     double r11,r12,r13,r21,r22,r23,r31,r32,r33 ;
@@ -290,6 +293,7 @@ mat33 nifti_mat33_mul( mat33 A , mat33 B )  /* multiply 2 3x3 matrices */
             + A.m[i][2] * B.m[2][j] ;
     return C ;
 }
+#endif
 #endif
 
 mat44 nifti_mat44_mul( mat44 A , mat44 B )  /* multiply 2 3x3 matrices */
@@ -315,6 +319,7 @@ mat33 nifti_mat33_transpose( mat33 A )  /* transpose 3x3 matrix */
 }
 
 #ifndef USING_R
+#ifndef USING_MGH_NIFTI_IO
 mat33 nifti_mat33_inverse( mat33 R )   /* inverse of 3x3 matrix */
 {
     double r11,r12,r13,r21,r22,r23,r31,r32,r33 , deti ;
@@ -337,6 +342,7 @@ mat33 nifti_mat33_inverse( mat33 R )   /* inverse of 3x3 matrix */
     Q.m[2][2] = deti*( r11*r22-r21*r12) ;
     return Q ;
 }
+
 
 float nifti_mat33_rownorm( mat33 A )  // max row norm of 3x3 matrix
 {
@@ -402,6 +408,7 @@ mat33 nifti_mat33_polar( mat33 A )
     }
     return Z ;
 }
+
 
 void nifti_mat44_to_quatern( mat44 R ,
                             float *qb, float *qc, float *qd,
@@ -571,6 +578,7 @@ mat44 nifti_mat44_inverse( mat44 R )
     Q.m[3][3] = (deti == 0.0l) ? 0.0l : 1.0l ; // failure flag if deti == 0
     return Q ;
 }
+#endif
 #endif
 
 // Eigen decomposition for symmetric 3x3 matrices, port of public domain Java Matrix library JAMA.
@@ -855,3 +863,10 @@ vec3 nifti_mat33_eig3(double bxx, double bxy, double bxz, double byy, double byz
     //printf("bvec = [%g 0 0; 0 %g 0; 0 0 %g]\n", v3.v[0], v3.v[1], v3.v[2]);
     return v3;
 }
+
+
+
+
+
+
+

--- a/console/nifti1_io_core.h
+++ b/console/nifti1_io_core.h
@@ -22,7 +22,7 @@ extern "C" {
 #include <string.h>
 
 #ifndef USING_R
-typedef struct {                   /** 4x4 matrix struct **/
+typedef struct {                   /** 3x3 matrix struct **/
     float m[3][3] ;
 } mat33 ;
 typedef struct {                   /** 4x4 matrix struct **/
@@ -74,8 +74,12 @@ ivec3 setiVec3(int x, int y, int z);
 vec3 setVec3(float x, float y, float z);
 vec4 setVec4(float x, float y, float z);
 #ifndef USING_R
+#ifndef USING_MGH_NIFTI_IO
 // This declaration differs from the equivalent function in the current nifti1_io.h, so avoid the clash
 void  swap_nifti_header ( struct nifti_1_header *h) ;
+#else
+void  swap_nifti_header ( struct nifti_1_header *h , int is_nifti ) ;
+#endif
 #endif
 vec4 nifti_vect44mat44_mul(vec4 v, mat44 m );
 void nifti_swap_2bytes( size_t n , void *ar );    // 2 bytes at a time
@@ -93,4 +97,4 @@ mat44 nifti_quatern_to_mat44( float qb, float qc, float qd,
 }
 #endif
 
-#endif
+#endif /* _NIFTI_IO_CORE_HEADER_ */

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -765,7 +765,11 @@ struct TDICOMdata clear_dicom_data() {
 	d.lastScanLoc = NAN;
 	d.TR = 0.0;
 	d.TE = 0.0;
+#ifdef USING_DCM2NIIXFSWRAPPER
+	d.TI = -1.0; // default when there is no TI in dicom file
+#else
 	d.TI = 0.0;
+#endif
 	d.flipAngle = 0.0;
 	d.bandwidthPerPixelPhaseEncode = 0.0;
 	d.acquisitionDuration = 0.0;
@@ -6820,7 +6824,7 @@ const uint32_t kEffectiveTE = 0x0018 + (0x9082 << 16);
 				if (bits == 1)
 					break;
 				//old style Burned-In
-				printMessage("Illegal/Obsolete DICOM: Overlay Bits Allocated must be 1, not %d\n", bits);
+				printMessage("Illegal/Obsolete DICOM (%s): Overlay Bits Allocated must be 1, not %d\n", fname, bits);
 				overlayOK = false;
 				break;
 			}
@@ -6829,7 +6833,7 @@ const uint32_t kEffectiveTE = 0x0018 + (0x9082 << 16);
 				if (pos == 0)
 					break;
 				//old style Burned-In
-				printMessage("Illegal/Obsolete DICOM: Overlay Bit Position shall be 0, not %d\n", pos);
+				printMessage("Illegal/Obsolete DICOM (%s): Overlay Bit Position shall be 0, not %d\n", fname, pos);
 				overlayOK = false;
 				break;
 			}
@@ -7500,7 +7504,7 @@ const uint32_t kEffectiveTE = 0x0018 + (0x9082 << 16);
 	//printf("%g\t\t%g\t%g\t%g\t%s\n", d.CSA.dtiV[0], d.CSA.dtiV[1], d.CSA.dtiV[2], d.CSA.dtiV[3], fname);
 	//printMessage("buffer usage %d %d %d\n",d.imageStart, lPos+lFileOffset, MaxBufferSz);
 	return d;
-} // readDICOM()
+} // readDICOMx()
 
 void setDefaultPrefs(struct TDCMprefs *prefs) {
 	prefs->isVerbose = false;

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -23,6 +23,24 @@ extern "C" {
     };
 #endif
 
+#ifdef USING_DCM2NIIXFSWRAPPER 
+typedef struct 
+{
+  struct nifti_1_header hdr0;
+
+  size_t         imgsz;
+  unsigned char *imgM;
+
+  struct TDICOMdata tdicomData;
+
+  struct TDTI *tdti;
+  int numDti;
+} MRIFSSTRUCT;
+
+MRIFSSTRUCT* nii_getMrifsStruct();
+void nii_clrMrifsStruct();
+#endif
+
 #define kNAME_CONFLICT_SKIP 0 //0 = write nothing for a file that exists with desired name
 #define kNAME_CONFLICT_OVERWRITE 1 //1 = overwrite existing file with same name
 #define kNAME_CONFLICT_ADD_SUFFIX 2 //default 2 = write with new suffix as a new file
@@ -59,6 +77,7 @@ extern "C" {
     void readIniFile (struct TDCMopts *opts, const char * argv[]);
     int nii_saveNIIx(char * niiFilename, struct nifti_1_header hdr, unsigned char* im, struct TDCMopts opts);
     int nii_loadDir(struct TDCMopts *opts);
+  int nii_loadDirCore(char *indir, struct TDCMopts* opts);
     void nii_SaveBIDS(char pathoutname[], struct TDICOMdata d, struct TDCMopts opts, struct nifti_1_header *h, const char * filename);
     int nii_createFilename(struct TDICOMdata dcm, char * niiFilename, struct TDCMopts opts);
     void  nii_createDummyFilename(char * niiFilename, struct TDCMopts opts);


### PR DESCRIPTION
1. Implement a wrapper class to interface with dcm2niix functions.
2. The wrapper class provides interface to convert dicom in mgz orientation.
3. The wrapper class and dcm2niix functions are compiled into libdcm2niixfs.a
   with -DUSING_DCM2NIIXFSWRAPPER -DUSING_MGH_NIFTI_IO.
4. When using libdcm2niixfs.a, instead of outputting .nii, *.bval, *.bvec to disk,
   nifti header, image data, TDICOMdata, & TDTI information are saved in MRIFSSTRUCT struct.
5. If libdcm2niixfs.a is compiled with -DUSING_MGH_NIFTI_IO, the application needs to link with nifti library.