### PR TITLE
Fix the example batch config to match defaults

### DIFF
--- a/BATCH.md
+++ b/BATCH.md
@@ -10,9 +10,9 @@ The configuration file should be in yaml format as shown in example `batch_confi
 ```yaml
 Options:
   isGz:             false
-  isFlipY:          false
+  isFlipY:          true
   isVerbose:        false
-  isCreateBIDS:     false
+  isCreateBIDS:     true
   isOnlySingleFile: false
 Files:
     -

--- a/batch_config.yml
+++ b/batch_config.yml
@@ -1,8 +1,8 @@
 Options:
   isGz:             false
-  isFlipY:          false
+  isFlipY:          true
   isVerbose:        false
-  isCreateBIDS:     false
+  isCreateBIDS:     true
   isOnlySingleFile: false
 
 Files:

--- a/console/main_console_batch.cpp
+++ b/console/main_console_batch.cpp
@@ -49,9 +49,9 @@ void showHelp(const char * argv[]) {
 	printf("### START YAML FILE ###\n");
 	printf("Options:\n");
 	printf("   isGz:             false\n");
-	printf("   isFlipY:          false\n");
+	printf("   isFlipY:          true\n");
 	printf("   isVerbose:        false\n");
-	printf("   isCreateBIDS:     false\n");
+	printf("   isCreateBIDS:     true\n");
 	printf("   isOnlySingleFile: false\n");
 	printf("Files:\n");
 	printf("   -\n");

--- a/docs/source/dcm2niibatch.rst
+++ b/docs/source/dcm2niibatch.rst
@@ -41,9 +41,9 @@ The configuration file should be in yaml format as shown in example *batch_confi
 
     Options:
       isGz:             false
-      isFlipY:          false
+      isFlipY:          true
       isVerbose:        false
-      isCreateBIDS:     false
+      isCreateBIDS:     true
       isOnlySingleFile: false
     Files:
         -


### PR DESCRIPTION
With this change, people who copy/paste the example batch configuration YAML will get the default behaviour. This could have saved me a lot of debugging :-)