### PR TITLE
Fix % escaping of sequence number when compiling with mySegmentByAcq

### DIFF
--- a/console/main_console.cpp
+++ b/console/main_console.cpp
@@ -82,7 +82,7 @@ void showHelp(const char *argv[], struct TDCMopts opts) {
 	printf("  -d : directory search depth. Convert DICOMs in sub-folders of in_folder? (0..9, default %d)\n", opts.dirSearchDepth);
 	printf("  -e : export as NRRD (y) or MGH (o) instead of NIfTI (y/n/o, default n)\n");
 #ifdef mySegmentByAcq
-#define kQstr " %%q=sequence number,"
+#define kQstr " %q=sequence number,"
 #else
 #define kQstr ""
 #endif


### PR DESCRIPTION
The current code leads to two % signs being printed in the help:

-f : filename (%a=antenna (coil) name, %b=basename, %c=comments, %d=description, %e=echo number, %f=folder name, %g=accession number, %i=ID of patient, %j=seriesInstanceUID, %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %o=mediaObjectInstanceUID, %p=protocol, **%%q**=sequence number, %r=instance number, %s=series number, %t=time, %u=acquisition number, %v=vendor, %x=study ID; %z=sequence name; default '%f_%p_%t_%s')