### PR TITLE
Addressing issue with bit masking 12bit data in signed 16bit type

### DIFF
--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -1617,8 +1617,7 @@ int headerDcm2Nii(struct TDICOMdata d, struct nifti_1_header *h, bool isComputeS
 		printMessage("Unsupported DICOM bit-depth %d with %d samples per pixel\n", d.bitsAllocated, d.samplesPerPixel);
 		return EXIT_FAILURE;
 	}
-	if ((h->datatype == DT_UINT16) && (d.bitsStored > 0) && (d.bitsStored < 16))
-		h->datatype = DT_INT16; // DT_INT16 is more widely supported, same representation for values 0..32767
+	
 	for (int i = 0; i < 8; i++) {
 		h->pixdim[i] = 0.0f;
 		h->dim[i] = 0;

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -5106,7 +5106,8 @@ void nii_mask12bit(unsigned char *img, struct nifti_1_header *hdr) {
 		return;
 	int16_t *img16 = (int16_t *)img;
 	for (int i = 0; i < nVox; i++)
-		img16[i] = img16[i] & 4095; //12 bit data ranges from 0..4095, any other values are overflow
+		img16[i] = (img16[i] << 4) >> 4; //12 bit data ranges from 0..4095, any other values are overflow. 
+                                     //Discard upper bits but preserve signage whenever allowed by compiler/architecture
 }
 
 unsigned char * nii_uint16toFloat32(unsigned char *img, struct nifti_1_header *hdr, int isVerbose) {


### PR DESCRIPTION
Good morning!

First, thank you for all of the work put into this utility. It has greatly benefitted my project.

[The Issue]
We recently came across a 12 bit T1 MR from an outside source that had negative values (among several other issues). When converting this dataset to nifti, the negative value would appear as intensities in the 4000 to 4095 range, which would display as white pixels/voxels. Initially, it looked like the intensities were getting wrapped around, but that lead us to review the code base. Long story short, we identified nii_mask12bit() as the problem function.

The mask operation is performing the truncation of the upper 4 bits as discussed in #251 . This is correct if it was not for the case that the nifti header says this is a 16bit signed dataset which tricks other tools into looking at bit 15 for the sign. In other words, to have a conversion that works in the wild (we can't tell the other tools to look in the 11th bit), we would need to reset the upper 4 bits to either 1s or 0s. 

[Proposed solution]
Instead of a mask, I propose to break the operation into two bit shifts of 4. One bit shift to the left to discard the upper 4 bit contents and set the carry flag and a bit shift to the right of 4 to set the bits to the carry flag contents.

[Considerations with this solution]
There's two areas I considered of relevance from a Computer Science perspective. 
1. Would bit shifting to the right always preserve the sign? The C standard does not fully define whether the right shift should preserve the sign, but all sources I looked into mention that most compilers and machines preserve the most significant bit in their implementation. Indeed, for GCC in an x86 machine this is the case (our architecture).
2. Should the bit shifting done in one line (for code clarity)? I looked at Compiler Explorer (https://godbolt.org/) using the snippet below and there are nuances. It turns out that GCC v4.8.5 and older Clang will optimize the line out as if we had never done anything to the bits. Newer GCC and Clang will instead opt to use SIMD for the operation but (crucially) will add the bit shift instructions when using -O2. Does the Release output use any optimization flags?
The way I worked around this is by braking the operation into two lines. Doing so seems to prevent GCC and Clang from optimizing the instructions out and allows them to use SIMD whenever appropriate.
`#include <stdint.h>
#define DT_INT16 4

struct nifti_1_header{
    short dim[8];        /*!< Data array dimensions.*/  /* short dim[8];        */
    short datatype;      /*!< Defines data type!    */  /* short datatype;      */
};

void nii_mask12bit(unsigned char *img, struct nifti_1_header *hdr) {
	//https://github.com/rordenlab/dcm2niix/issues/251
	int16_t *img16 = (int16_t *)img;
	for (int i = 0; i < 4; i++){
        img16[i] = img16[i] << 4; 
        img16[i] = img16[i] >> 4; //12 bit data ranges from 0..4095, any other values are overflow. 
		                                 //Discard upper bits but preserve signage.
    }
}

int main(){
    nifti_1_header hdr;
    int16_t img[4] = {-80,24,22414,-24};
    nii_mask12bit((unsigned char*)img, &hdr);
    return 0;
}`

Should we keep the function name as nii_mask12bit given my solution no longer uses a mask?
What else do you think I should consider in my PR to make my proposed solution more complete for this project?

Let me know what I should make clearer with my PR/Issue.
Thank you!
![image](https://user-images.githubusercontent.com/127312735/223754477-08073aec-37c9-4b6d-8799-b27a1ddb17de.png)
![image](https://user-images.githubusercontent.com/127312735/223755002-625ce549-9bc9-47fa-ac94-d01fc457101d.png)
![image](https://user-images.githubusercontent.com/127312735/223754819-007f74fc-d825-4c33-8d98-f864aff306b3.png)
