### PR TITLE
dcm2niix_fswrapper and libdcm2niixfs.a

### DIFF
--- a/console/dcm2niix_fswrapper.h
+++ b/console/dcm2niix_fswrapper.h
@@ -17,7 +17,7 @@ class dcm2niix_fswrapper
 {
 public:
   // set TDCMopts defaults, overwrite settings to output in mgz orientation.
-  static void setOpts(const char* dcmindir, const char* niioutdir=NULL, bool createBIDS=false);
+  static void setOpts(const char* dcmindir, const char* niioutdir=NULL, bool createBIDS=false, int ForceStackSameSeries=1);
 
   // interface to isDICOMfile() in nii_dicom.cpp
   static bool isDICOM(const char* file);
@@ -32,10 +32,18 @@ public:
   // return nifti header saved in MRIFSSTRUCT 
   static nifti_1_header* getNiiHeader(void);
 
+  // interface to nii_getMrifsStructVector()
+  static std::vector<MRIFSSTRUCT>* getMrifsStructVector(void);
+
   // return image data saved in MRIFSSTRUCT
   static const unsigned char* getMRIimg(void);
 
-  static void dicomDump(const char* dicomdir);
+  static void dicomDump(const char* dicomdir, const char *series_info, bool max=false, bool extrainfo=false);
+
+  //
+  static void seriesInfoDump(FILE *fpdump, const MRIFSSTRUCT *pmrifsStruct);
+
+  static const char *mfrCode2Str(int code);
 
 private:
   static struct TDCMopts tdcmOpts;

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -243,7 +243,7 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
         float frameReferenceTime, frameDuration, ecat_isotope_halflife, ecat_dosage;
         float pixelPaddingValue;  // used for both FloatPixelPaddingValue (0028, 0122) and PixelPaddingValue (0028, 0120); NaN if not present.
         double imagingFrequency, acquisitionDuration, triggerDelayTime, RWVScale, RWVIntercept, dateTime, acquisitionTime, acquisitionDate, bandwidthPerPixelPhaseEncode;
-        char parallelAcquisitionTechnique[kDICOMStr], radiopharmaceutical[kDICOMStr], convolutionKernel[kDICOMStr], unitsPT[kDICOMStr], decayCorrection[kDICOMStr], attenuationCorrectionMethod[kDICOMStr],reconstructionMethod[kDICOMStr];
+        char parallelAcquisitionTechnique[kDICOMStr], radiopharmaceutical[kDICOMStr], convolutionKernel[kDICOMStr], unitsPT[kDICOMStr], decayCorrection[kDICOMStr], attenuationCorrectionMethod[kDICOMStr],reconstructionMethod[kDICOMStr], transferSyntax[kDICOMStr];
         char prescanReuseString[kDICOMStr], imageOrientationText[kDICOMStr], pulseSequenceName[kDICOMStr], coilElements[kDICOMStr], coilName[kDICOMStr], phaseEncodingDirectionDisplayedUIH[kDICOMStr], imageBaseName[kDICOMStr], stationName[kDICOMStr], softwareVersions[kDICOMStr], deviceSerialNumber[kDICOMStr], institutionName[kDICOMStr], referringPhysicianName[kDICOMStr], instanceUID[kDICOMStr], seriesInstanceUID[kDICOMStr], studyInstanceUID[kDICOMStr], bodyPartExamined[kDICOMStr], procedureStepDescription[kDICOMStr], imageTypeText[kDICOMStr], imageType[kDICOMStr], institutionalDepartmentName[kDICOMStr], manufacturersModelName[kDICOMStr], patientID[kDICOMStr], patientOrient[kDICOMStr], patientName[kDICOMStr], accessionNumber[kDICOMStr], seriesDescription[kDICOMStr], studyID[kDICOMStr], sequenceName[kDICOMStr], protocolName[kDICOMStr],sequenceVariant[kDICOMStr],scanningSequence[kDICOMStr], patientBirthDate[kDICOMStr], patientAge[kDICOMStr],  studyDate[kDICOMStr],studyTime[kDICOMStr];
         char deepLearningText[kDICOMStrLarge], scanOptions[kDICOMStrLarge], institutionAddress[kDICOMStrLarge], imageComments[kDICOMStrLarge];
         uint32_t dimensionIndexValues[MAX_NUMBER_OF_DIMENSIONS];
@@ -276,6 +276,9 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
     int headerDcm2Nii2(struct TDICOMdata d, struct TDICOMdata d2, struct nifti_1_header *h, int isVerbose);
     int headerDcm2Nii(struct TDICOMdata d, struct nifti_1_header *h, bool isComputeSForm) ;
     unsigned char * nii_loadImgXL(char* imgname, struct nifti_1_header *hdr, struct TDICOMdata dcm, bool iVaries, int compressFlag, int isVerbose, struct TDTI4D *dti4D);
+#ifdef USING_DCM2NIIXFSWRAPPER
+    void remove_specialchars(char *buf);
+#endif
 #ifdef  __cplusplus
 }
 #endif

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -4,6 +4,38 @@
 #ifndef MRIpro_nii_batch_h
 #define MRIpro_nii_batch_h
 
+#ifdef USING_DCM2NIIXFSWRAPPER
+#include "nifti1.h"
+#include "nii_dicom.h"
+#include <vector>
+
+struct MRIFSSTRUCT
+{
+  struct nifti_1_header hdr0;
+
+  size_t         imgsz;
+  unsigned char *imgM;
+
+  struct TDICOMdata tdicomData;
+  char namePostFixes[256];
+  char *dicomfile;
+
+  int nDcm;
+  char **dicomlst;
+
+  struct TDTI *tdti;
+  int numDti;
+};
+
+MRIFSSTRUCT* nii_getMrifsStruct();
+void nii_clrMrifsStruct();
+
+std::vector<MRIFSSTRUCT>* nii_getMrifsStructVector();
+void nii_clrMrifsStructVector();
+
+void dcmListDump(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata dcmList[], struct TSearchList *nameList, struct TDCMopts opts);
+#endif
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
@@ -22,22 +54,6 @@ extern "C" {
         std::vector<std::string> files;
     };
 #endif
-
-typedef struct 
-{
-  struct nifti_1_header hdr0;
-
-  size_t         imgsz;
-  unsigned char *imgM;
-
-  struct TDICOMdata tdicomData;
-
-  struct TDTI *tdti;
-  int numDti;
-} MRIFSSTRUCT;
-
-MRIFSSTRUCT* nii_getMrifsStruct();
-void nii_clrMrifsStruct();
 
 #define kNAME_CONFLICT_SKIP 0 //0 = write nothing for a file that exists with desired name
 #define kNAME_CONFLICT_OVERWRITE 1 //1 = overwrite existing file with same name

--- a/console/nii_foreign.h
+++ b/console/nii_foreign.h
@@ -3,11 +3,13 @@
 #ifndef _NII_FOREIGN_
 #define _NII_FOREIGN_
 
+#include "nii_dicom_batch.h"
+
 #ifdef  __cplusplus
 extern "C" {
 #endif
 
-#include "nii_dicom_batch.h"
+//#include "nii_dicom_batch.h"
 
 //int  open_foreign (const char *fn);
 int  convert_foreign (const char *fn, struct TDCMopts opts);


### PR DESCRIPTION
  1. save dicom file list in MRIFSSTRUCT, return vector of MRIFSSTRUCT for multi-echo scans if isForceStackSameSeries = 0 (-m n)
  2. change output file format to "%4s.%d" from "%4s.%p" to be consistent with Freesurfer dcmunpack
  3. remove space, [, ] from scan description
  4. implement isDumpNotConvert option to retrieve dicom info only
  5. dcm2niix_fswrapper::dicomDump() - output information of series to be converted, and seriesNum-dicomflst.txt in the same directory as series-info.dat; dcm2niix_fswrapper::seriesInfoDump() - print information for given dicom series
  6. don't use std::max() from <algorithm> (fix Freesurfer ubuntu18 compiler error)