### PR TITLE
Documentation fix for GE TotalReadoutTime.

### DIFF
--- a/GE/README.md
+++ b/GE/README.md
@@ -60,6 +60,7 @@ NotPhysicalNumberOfAcquiredPELinesGE = (ceil((1/Round_factor) * PE_AcquisitionMa
 NotPhysicalTotalReadOutTimeGE = (NotPhysicalNumberOfAcquiredPELinesGE - 1) * EchoSpacing * 0.000001
 ```
 
+with `EchoSpacing` referring to the GE private DICOM field "(0043,102C) Effective Echo Spacing". 
 Then, the formula for FSL's definition of `EffectiveEchoSpacing` and `TotalReadoutTime` (in seconds) are:
 
 ```


### PR DESCRIPTION
It is now clarified that the `EchoSpacing` variable is the GE private DICOM field "(0043,102C) Effective Echo Spacing".

On branch fix-documentation-GE-TotalReadoutTime
Changes to be committed:
	modified:   GE/README.md