### PR TITLE
Support GE non-HFS DTI bvec

### DIFF
--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -50,7 +50,7 @@ extern "C" {
     #define kCPUsuf " " //unknown CPU
 #endif
 
-#define kDCMdate "v1.0.20230706"
+#define kDCMdate "v1.0.20230807"
 #define kDCMvers kDCMdate " " kJP2suf kLSsuf kCCsuf kCPUsuf
 
 static const int kMaxEPI3D = 1024; //maximum number of EPI images in Siemens Mosaic

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -297,8 +297,7 @@ void geCorrectBvecs(struct TDICOMdata *d, int sliceDir, struct TDTI *vx, int isV
 	if ((toupper(d->patientOrient[0]) == 'H') && (toupper(d->patientOrient[1]) == 'F') && (toupper(d->patientOrient[2]) == 'S'))
 		; //participant was head first supine
 	else {
-		printMessage("GE DTI directions require head first supine acquisition\n");
-		return;
+		printWarning("Limited validation for non-HFS (Head first supine) GE DTI: confirm gradient vector transformation\n");
 	}
 	bool col = false;
 	if (d->phaseEncodingRC == 'C')


### PR DESCRIPTION
While current dcm2niix generates the following message for GE non-HFS (i.e. feet-first) DTI, 
"GE DTI directions require head first supine acquisition"
Diffusion gradient vector (*.bvec) will be generated without any required conversion. So, bvec will be inaccurate as shown below

This pull request enables the geCorrectBvecs() routine for GE non-HFS DTI with the following warning message:
"Limited validation for non-HFS (Head first supine) GE DTI: confirm gradient vector transformation"

The bvec conversion for non-HFS would be same as HFS on GE based on [this validation dataset](https://gehealthcare-amer.my.salesforce.com/sfc/p/30000001F94O/a/3a000000YL6c/3fX_agno5e94ADHAdZm22o8khDG78SDpYh1eQgrSLzQ):
Both Head-first and feet-first Knee DTI with both freq. encoding directions: RL and AP collected on the same volunteer within the same exam.
   
![Screenshot 2023-08-07 at 3 49 32 PM](https://github.com/rordenlab/dcm2niix/assets/72111485/56381b77-0117-42f4-a2bf-8e7c4093db4d)

