### PR TITLE
run codespell throughout - fix 2 typos added in `development`

### DIFF
--- a/BidsGuess/README.md
+++ b/BidsGuess/README.md
@@ -51,7 +51,7 @@ The `BidsGuess` will typically include a [`_run-` entity](https://bids-specifica
 
 ## The dir entity
 
-The `BidsGuess` will typically include a [`_dir-` entity](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#dir) for modalities when required by the BIDS validator. This field is redunant with the JSON `PhaseEncodingDirection` field. Note that the JSON uses the values `j`, `j-`, `k` and `k-` to specify row versus column and polarity. In contrast, the BidsGuess will use the `AP`, `PA`, `LR`, and `RL` tags though note these tags will only be correct for axial acquisitions. Note that it is impossible to infer phase encoding polarity for Philips data, so this entity will not be populated leading to errors from the bids-validator.
+The `BidsGuess` will typically include a [`_dir-` entity](https://bids-specification.readthedocs.io/en/stable/appendices/entities.html#dir) for modalities when required by the BIDS validator. This field is redundant with the JSON `PhaseEncodingDirection` field. Note that the JSON uses the values `j`, `j-`, `k` and `k-` to specify row versus column and polarity. In contrast, the BidsGuess will use the `AP`, `PA`, `LR`, and `RL` tags though note these tags will only be correct for axial acquisitions. Note that it is impossible to infer phase encoding polarity for Philips data, so this entity will not be populated leading to errors from the bids-validator.
 
 ## Limitations
 

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -6564,7 +6564,7 @@ void setBidsSiemens(struct TDICOMdata *d, int nConvert, int isVerbose, const cha
 		strcpy(dataTypeBIDS, "anat");
 		strcpy(modalityBIDS, "angio");
 	} else if (strstr(seqDetails, "ep_seg_fid") != NULL) {
-		//n.b. large echoTrainLength even for single echo acquition
+		//n.b. large echoTrainLength even for single echo acquisition
 		strcpy(dataTypeBIDS, "anat");
 		strcpy(modalityBIDS, "T2starw");
 		isPart = true;


### PR DESCRIPTION
should I propose https://github.com/pre-commit/pre-commit config so codespell runs before each commit? ;-)