### PR TITLE
Update nii_dicom_batch.cpp

### DIFF
--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -64,6 +64,7 @@ static const int kMaxDTI4D = kMaxSlice2D; //issue460: maximum number of DTI dire
 
 #define kDICOMStr 66 //64 characters plus NULL https://github.com/rordenlab/dcm2niix/issues/268
 #define kDICOMStrLarge 256
+#define kDICOMStrExtraLarge 65536
 
 #define kMANUFACTURER_UNKNOWN  0
 #define kMANUFACTURER_SIEMENS  1

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -599,7 +599,7 @@ void readKeyStr(const char *key, char *buffer, int remLength, char *outStr) {
 	tmpstr[1] = 0;
 	bool isQuote = false;
 	while ((i < remLength) && (keyPos[i] != 0x0A)) {
-		if ((isQuote) && (keyPos[i] != '"') && (outLen < kDICOMStrLarge)) {
+		if ((isQuote) && (keyPos[i] != '"') && (outLen < (kDICOMStrLarge-1))) {
 			tmpstr[0] = keyPos[i];
 			strcat(outStr, tmpstr);
 			outLen++;


### PR DESCRIPTION
Changing maximal length of string read from Siemens CSA header, to prevent an overflow issue, where length of strcat(outStr, tmpstr) became 1 byte too long as tmpstr is of length 2.

(We have files where the WipMemBlock is even longer than kDICOMStrLarge and this caused an overflow which nulled pulseSequenceDetails, causing further problems downstream)