### PR TITLE
Development

### DIFF
--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -64,6 +64,8 @@ static const int kMaxDTI4D = kMaxSlice2D; //issue460: maximum number of DTI dire
 
 #define kDICOMStr 66 //64 characters plus NULL https://github.com/rordenlab/dcm2niix/issues/268
 #define kDICOMStrLarge 256
+#define kDICOMStrExtraLarge 65536 // for Siemens WipMemBlock only
+
 
 #define kMANUFACTURER_UNKNOWN  0
 #define kMANUFACTURER_SIEMENS  1

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -617,7 +617,7 @@ float readKeyFloat(const char *key, char *buffer, int remLength) { //look for te
 	return atof(str);
 } //readKeyFloat()
 
-void readKeyStr(const char *key, char *buffer, int remLength, char *outStr) {
+void readKeyStr(const char *key, char *buffer, int remLength, char *outStr, int outStrLen) {
 	//if key is CoilElementID.tCoilID the string 'CoilElementID.tCoilID = 	""Head_32""' returns 'Head32'
 	strcpy(outStr, "");
 	char *keyPos = (char *)memmem(buffer, remLength, key, strlen(key));
@@ -629,7 +629,7 @@ void readKeyStr(const char *key, char *buffer, int remLength, char *outStr) {
 	tmpstr[1] = 0;
 	bool isQuote = false;
 	while ((i < remLength) && (keyPos[i] != 0x0A)) {
-		if ((isQuote) && (keyPos[i] != '"') && (outLen < (kDICOMStrLarge-1))) {
+		if ((isQuote) && (keyPos[i] != '"') && (outLen < outStrLen)) {
 			tmpstr[0] = keyPos[i];
 			strcat(outStr, tmpstr);
 			outLen++;
@@ -641,6 +641,10 @@ void readKeyStr(const char *key, char *buffer, int remLength, char *outStr) {
 		}
 		i++;
 	}
+} //readKeyStr()
+
+void readKeyStr(const char *key, char *buffer, int remLength, char *outStr) {
+    readKeyStr(key, buffer, remLength, outStr, kDICOMStrLarge);
 } //readKeyStr()
 
 int phoenixOffsetCSASeriesHeader(unsigned char *buff, int lLength) {
@@ -832,7 +836,7 @@ void siemensCsaAscii(const char *filename, TCsaAscii *csaAscii, int csaOffset, i
 		char keyStrSeq[] = "tSequenceFileName";
 		readKeyStr(keyStrSeq, keyPos, csaLengthTrim, pulseSequenceDetails);
 		char keyStrWipMemBlock[] = "sWipMemBlock.tFree";
-		readKeyStr(keyStrWipMemBlock, keyPos, csaLengthTrim, wipMemBlock);
+		readKeyStr(keyStrWipMemBlock, keyPos, csaLengthTrim, wipMemBlock, kDICOMStrExtraLarge);
 		char keyStrPn[] = "tProtocolName";
 		readKeyStr(keyStrPn, keyPos, csaLengthTrim, protocolName);
 		char keyStrTE0[] = "alTE[0]";
@@ -1168,7 +1172,7 @@ void rescueProtocolName(struct TDICOMdata *d, const char *filename) {
 		return;
 #ifdef myReadAsciiCsa
 	float shimSetting[8];
-	char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrLarge];
+	char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrExtraLarge];
 	TCsaAscii csaAscii;
 	siemensCsaAscii(filename, &csaAscii, d->CSA.SeriesHeader_offset, d->CSA.SeriesHeader_length, shimSetting, coilID, consistencyInfo, coilElements, pulseSequenceDetails, fmriExternalInfo, protocolName, wipMemBlock);
 	if (strlen(protocolName) >= kDICOMStr)
@@ -1607,7 +1611,7 @@ tse3d: T2*/
 	if ((d.manufacturer == kMANUFACTURER_SIEMENS) && (d.CSA.SeriesHeader_offset > 0) && (d.CSA.SeriesHeader_length > 0)) {
 		float pf = 1.0f; //partial fourier
 		float shimSetting[8];
-		char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrLarge];
+		char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrExtraLarge];
 		TCsaAscii csaAscii;
 		siemensCsaAscii(filename, &csaAscii, d.CSA.SeriesHeader_offset, d.CSA.SeriesHeader_length, shimSetting, coilID, consistencyInfo, coilElements, pulseSequenceDetails, fmriExternalInfo, protocolName, wipMemBlock);
 		if ((d.phaseEncodingLines < 1) && (csaAscii.phaseEncodingLines > 0))
@@ -1786,7 +1790,22 @@ tse3d: T2*/
 		// https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#common-metadata-fields-applicable-to-both-pcasl-and-pasl
 		if (((isPASL) || (isPCASL)) && (csaAscii.interp <= 0))
 			fprintf(fp, "\t\"AcquisitionVoxelSize\": [\n\t\t%g,\n\t\t%g,\n\t\t%g\t],\n", d.xyzMM[1], d.xyzMM[2], d.zThick);
-		//general properties
+		
+        // lund free waveform sequence
+        if (strstr(pulseSequenceDetails, "ep2d_diff_fwf") != 0)
+        {
+            for (int i = 0; i < kMaxWipFree; i++) {
+                if (!isnan(csaAscii.adFree[i]))
+                    fprintf(fp, "\t\"FWF_adFree[%i]\": %g,\n", i, csaAscii.adFree[i]);
+            }
+
+            for (int i = 0; i < kMaxWipFree; i++) {
+                if (!isnan(csaAscii.alFree[i]))
+                    fprintf(fp, "\t\"FWF_alFree[%i]\": %g,\n", i, csaAscii.alFree[i]);
+            }
+        }
+        
+        //general properties
 		if ((csaAscii.partialFourier > 0) && ((d.modality == kMODALITY_MR))) { //check MR, e.g. do not report for Siemens PET
 			//https://github.com/ismrmrd/siemens_to_ismrmrd/blob/master/parameter_maps/IsmrmrdParameterMap_Siemens_EPI_FLASHREF.xsl
 			if (csaAscii.partialFourier == 1)
@@ -6445,7 +6464,7 @@ void setBidsSiemens(struct TDICOMdata *d, int nConvert, int isVerbose, const cha
 	if ((d->CSA.SeriesHeader_offset > 0) && (d->CSA.SeriesHeader_length > 0)) {
 		float pf = 1.0f; //partial fourier
 		float shimSetting[8];
-		char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], wipMemBlock[kDICOMStrLarge];
+		char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], wipMemBlock[kDICOMStrExtraLarge];
 		TCsaAscii csaAscii;
 		siemensCsaAscii(filename, &csaAscii, d->CSA.SeriesHeader_offset, d->CSA.SeriesHeader_length, shimSetting, coilID, consistencyInfo, coilElements, seqDetails, fmriExternalInfo, protocolName, wipMemBlock);
 		inv1 = csaAscii.alTI[0] / 1000.0;
@@ -7223,7 +7242,7 @@ void rescueSliceTimingSiemens(struct TDICOMdata *d, int verbose, int nSL, const 
 		return;
 #ifdef myReadAsciiCsa
 	float shimSetting[8];
-	char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrLarge];
+	char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrExtraLarge];
 	TCsaAscii csaAscii;
 	siemensCsaAscii(filename, &csaAscii, d->CSA.SeriesHeader_offset, d->CSA.SeriesHeader_length, shimSetting, coilID, consistencyInfo, coilElements, pulseSequenceDetails, fmriExternalInfo, protocolName, wipMemBlock);
 	int ucMode = csaAscii.ucMode;

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -1820,7 +1820,7 @@ tse3d: T2*/
 			fprintf(fp, "\t\"AcquisitionVoxelSize\": [\n\t\t%g,\n\t\t%g,\n\t\t%g\t],\n", d.xyzMM[1], d.xyzMM[2], d.zThick);
 		
         // lund free waveform sequence, see https://github.com/filip-szczepankiewicz/fwf_sequence_tools
-        if (strstr(pulseSequenceDetails, "ep2d_diff_fwf") != 0)
+        if ( (strstr(pulseSequenceDetails, "ep2d_diff_fwf") != 0) || (strstr(pulseSequenceDetails, "ep2d_diff_sms_fwf_simple") != 0))
         {
             for (int i = 0; i < kMaxWipFree; i++) {
                 if (!isnan(csaAscii.adFree[i]))

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -629,7 +629,7 @@ void readKeyStr(const char *key, char *buffer, int remLength, char *outStr) {
 	tmpstr[1] = 0;
 	bool isQuote = false;
 	while ((i < remLength) && (keyPos[i] != 0x0A)) {
-		if ((isQuote) && (keyPos[i] != '"') && (outLen < kDICOMStrLarge)) {
+		if ((isQuote) && (keyPos[i] != '"') && (outLen < (kDICOMStrLarge-1))) {
 			tmpstr[0] = keyPos[i];
 			strcat(outStr, tmpstr);
 			outLen++;


### PR DESCRIPTION
First commit: Changing maximal length of string read from Siemens CSA header, to prevent an overflow issue, where length of strcat(outStr, tmpstr) became 1 byte too long as tmpstr is of length 2.

(We have files where the WipMemBlock is even longer than kDICOMStrLarge and this caused an overflow which nulled pulseSequenceDetails, causing further problems downstream)

Second commit: Adding support to write out WipMemBlock strings longer than 256 bytes, and adding support to write out all alFree/adFree items of the SiemensCSAHeader for diffusion MRI data acquired with the free waveform patch from Lund University. Info on how to use the resulting JSON file can be found here: https://github.com/markus-nilsson/fwf_header_tools/tree/master/siemens#alternative-approach

(Generated a pull request for this to the master branch last Friday, sorry for that misstake)