### PR TITLE
fix gantry tilt float bug (#782)

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -2914,7 +2914,7 @@ float computeGantryTiltPrecise(struct TDICOMdata d1, struct TDICOMdata d2, int i
 	float dotX = dotProduct(slice_vector90, slice_vector);
 	float cosX = dotX / (len * len90);
 	float degX = acos(cosX) * (180.0 / M_PI); //arccos, radian -> degrees
-	if (!isSameFloat(cosX, 1.0))
+	if (!(isSameFloat(cosX, 1.0) || cosX > 1.0))
 		ret = degX;
 	if ((isSameFloat(ret, 0.0)) && (isSameFloat(ret, d1.gantryTilt)))
 		return 0.0;


### PR DESCRIPTION
Small change to fix #782. Testing clean in `dcm_qa`/`master` except for the presence of a new BIDS tag "BidsGuess" in the json files. Things were looking good in `dcm_qa_uih` but then I updated submodule's master branch and now I'm getting a handful of binary files differ messages. I didn't see anything obviously different in the header and the voxel data appears to be the same.
Results appear the same between this patch and the previous release version on `dcm_qa_ct` except for "BidsGuess" and the issues reported in https://github.com/neurolabusc/dcm_qa_ct/issues/1

