### PR TITLE
DCM2NIIXFSLIB changes

### DIFF
--- a/console/dcm2niix_fswrapper.h
+++ b/console/dcm2niix_fswrapper.h
@@ -17,7 +17,7 @@ class dcm2niix_fswrapper
 {
 public:
   // set TDCMopts defaults, overwrite settings to output in mgz orientation.
-  static void setOpts(const char* dcmindir, const char* niioutdir=NULL, bool createBIDS=false, int ForceStackSameSeries=1);
+  static void setOpts(const char* dcmindir, const char* dcm2niixopts=NULL);
 
   // interface to isDICOMfile() in nii_dicom.cpp
   static bool isDICOM(const char* file);
@@ -47,6 +47,9 @@ public:
 
 private:
   static struct TDCMopts tdcmOpts;
+
+  //
+  static void __setDcm2niixOpts(const char *dcm2niixopts);
 };
 
 #endif

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -8342,6 +8342,19 @@ int saveDcm2Nii(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata dcmLi
     mrifsStruct.dicomlst = new char*[nConvert];
     mrifsStruct.nDcm  = nConvert;
 
+    // retrieve pulseSequenceDetails (tSequenceFileName)
+    struct TDICOMdata *d = &(mrifsStruct.tdicomData);
+    strcpy(mrifsStruct.pulseSequenceDetails, "");
+    if ((d->manufacturer == kMANUFACTURER_SIEMENS) && (d->CSA.SeriesHeader_offset > 0) && (d->CSA.SeriesHeader_length > 0)) {
+      float shimSetting[8];
+      char protocolName[kDICOMStrLarge], fmriExternalInfo[kDICOMStrLarge], coilID[kDICOMStrLarge], consistencyInfo[kDICOMStrLarge], coilElements[kDICOMStrLarge], pulseSequenceDetails[kDICOMStrLarge], wipMemBlock[kDICOMStrLarge];
+      TCsaAscii csaAscii;
+      siemensCsaAscii(nameList->str[indx0], &csaAscii, d->CSA.SeriesHeader_offset, d->CSA.SeriesHeader_length, shimSetting, coilID, consistencyInfo, coilElements, pulseSequenceDetails, fmriExternalInfo, protocolName, wipMemBlock);
+      if (strlen(pulseSequenceDetails) >= kDICOMStr)
+        pulseSequenceDetails[kDICOMStr - 1] = 0;
+      strcpy(mrifsStruct.pulseSequenceDetails, pulseSequenceDetails);
+    }
+    
     dcmListDump(nConvert, dcmSort, dcmList, nameList, opts);
 
     mrifsStruct_vector.push_back(mrifsStruct);
@@ -10008,10 +10021,16 @@ void dcmListDump(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata dcmL
       memset(mrifsStruct.dicomlst[i], 0, strlen(nameList->str[indx])+1);
       memcpy(mrifsStruct.dicomlst[i], nameList->str[indx], strlen(nameList->str[indx]));
       
-      printMessage("%s %ld %s %s %f %f %f %f\\%f %c %f %s %s\n",
+      FILE *fp = stdout;
+      const char *imagelist = getenv("MGH_DCMUNPACK_IMAGELIST");
+      if (imagelist != NULL)
+        fp = fopen(imagelist, "a");
+
+      fprintf(fp, "%s %ld %s %s %f %f %f %f\\%f %c %f %s %s\n",
                    dcmList[indx].patientName, dcmList[indx].seriesNum, dcmList[indx].studyDate, dcmList[indx].studyTime,
                    dcmList[indx].TE, dcmList[indx].TR, dcmList[indx].flipAngle, dcmList[indx].xyzMM[1], dcmList[indx].xyzMM[2], 
                    dcmList[indx].phaseEncodingRC, dcmList[indx].pixelBandwidth, nameList->str[indx], dcmList[indx].imageType);
+      fclose(fp);
     }
 }
 #endif

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -16,6 +16,7 @@ struct MRIFSSTRUCT
   size_t         imgsz;
   unsigned char *imgM;
 
+  char pulseSequenceDetails[kDICOMStr];
   struct TDICOMdata tdicomData;
   char namePostFixes[256];
   char *dicomfile;


### PR DESCRIPTION
  - dcm2niix_fswrapper: allow subset of dcm2niix options to be set through mri_convert
  - dcmListDump(): use environment variable MGH_DCMUNPACK_IMAGELIST to communicate with dcm2niix where to output imagelist.dat
  - retrieve/output 'pulseSequenceDetails (tSequenceFileName)' from DICOM CSA header (0029,1020)