### PR TITLE
Add DeidentificationMethod and DeidentificationMethodCodeSequence to json

### DIFF
--- a/console/dcm2niix_fswrapper.cpp
+++ b/console/dcm2niix_fswrapper.cpp
@@ -352,4 +352,8 @@ void dcm2niix_fswrapper::seriesInfoDump(FILE *fpdump, const MRIFSSTRUCT *pmrifsS
 
   // dcm2niix doesn't seem to retrieve this  0x51, 0x1016
   //fprintf(fpdump, "SiemensCrit %s\n",e->d.string);
+
+  // kDeidentificationMethod 0x0012 + (0x0063 << 16) // '0012' '0063' 'LO' 'DeidentificationMethod'
+  fprintf(fpdump, "DeidentificationMethod %s\n", tdicomData->deidentificationMethod);
+
 }

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -184,6 +184,9 @@ static const int kMaxOverlay = 16; //even group values 0x6000..0x601E
 // Maximum number of dimensions for .dimensionIndexValues, i.e. possibly the
 // number of axes in the output .nii.
 static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
+// Maximum supported number of entries in DeidentificationMethodCodeSequence
+// Any additional will be ignored
+static const uint8_t MAX_DEID_CS = 10;
     struct TDTI {
         float V[4];
         //int totalSlicesIn4DOrder;
@@ -235,9 +238,16 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
         char bidsEntitySuffix[kDICOMStrLarge]; //anat, func, dwi
         char bidsTask[kDICOMStr]; //rest, naming40
     };
+    struct TDeIDCodeSequence {
+      char CodeValue[kDICOMStr];
+      char CodeMeaning[kDICOMStrLarge];
+      char CodingSchemeDesignator[kDICOMStr];
+      char CodingSchemeVersion[kDICOMStr];
+    };
     struct TDICOMdata {
         long seriesNum;
         int xyzDim[5];
+        int deID_CS_n = 0;
         uint32_t coilCrc, seriesUidCrc, instanceUidCrc;
         int overlayStart[kMaxOverlay];
         int postLabelDelay, shimGradientX, shimGradientY, shimGradientZ, phaseNumber, spoiling, mtState, partialFourierDirection, interp3D, aslFlags, durationLabelPulseGE, epiVersionGE, internalepiVersionGE, maxEchoNumGE, rawDataRunNumber, numberOfTR, numberOfImagesInGridUIH, numberOfDiffusionT2GE, numberOfDiffusionDirectionGE, tensorFileGE, diffCyclingModeGE, phaseEncodingGE, protocolBlockStartGE, protocolBlockLengthGE, modality, dwellTime, effectiveEchoSpacingGE, phaseEncodingLines, phaseEncodingSteps, frequencyEncodingSteps, phaseEncodingStepsOutOfPlane, echoTrainLength, echoNum, sliceOrient, manufacturer, converted2NII, acquNum, imageNum, imageStart, imageBytes, bitsStored, bitsAllocated, samplesPerPixel,locationsInAcquisition, locationsInAcquisitionConflict, compressionScheme;
@@ -248,12 +258,13 @@ static const uint8_t MAX_NUMBER_OF_DIMENSIONS = 8;
         float pixelPaddingValue;  // used for both FloatPixelPaddingValue (0028, 0122) and PixelPaddingValue (0028, 0120); NaN if not present.
         double imagingFrequency, acquisitionDuration, triggerDelayTime, RWVScale, RWVIntercept, dateTime, acquisitionTime, acquisitionDate, bandwidthPerPixelPhaseEncode;
         char parallelAcquisitionTechnique[kDICOMStr], radiopharmaceutical[kDICOMStr], convolutionKernel[kDICOMStr], unitsPT[kDICOMStr], decayCorrection[kDICOMStr], attenuationCorrectionMethod[kDICOMStr],reconstructionMethod[kDICOMStr], transferSyntax[kDICOMStr];
-        char prescanReuseString[kDICOMStr], imageOrientationText[kDICOMStr], pulseSequenceName[kDICOMStr], coilElements[kDICOMStr], coilName[kDICOMStr], phaseEncodingDirectionDisplayedUIH[kDICOMStr], imageBaseName[kDICOMStr], stationName[kDICOMStr], softwareVersions[kDICOMStr], deviceSerialNumber[kDICOMStr], institutionName[kDICOMStr], referringPhysicianName[kDICOMStr], instanceUID[kDICOMStr], seriesInstanceUID[kDICOMStr], studyInstanceUID[kDICOMStr], bodyPartExamined[kDICOMStr], procedureStepDescription[kDICOMStr], imageTypeText[kDICOMStr], imageType[kDICOMStr], institutionalDepartmentName[kDICOMStr], manufacturersModelName[kDICOMStr], patientID[kDICOMStr], patientOrient[kDICOMStr], patientName[kDICOMStr], accessionNumber[kDICOMStr], seriesDescription[kDICOMStr], studyID[kDICOMStr], sequenceName[kDICOMStr], protocolName[kDICOMStr],sequenceVariant[kDICOMStr],scanningSequence[kDICOMStr], patientBirthDate[kDICOMStr], patientAge[kDICOMStr],  studyDate[kDICOMStr],studyTime[kDICOMStr];
+        char prescanReuseString[kDICOMStr], imageOrientationText[kDICOMStr], pulseSequenceName[kDICOMStr], coilElements[kDICOMStr], coilName[kDICOMStr], phaseEncodingDirectionDisplayedUIH[kDICOMStr], imageBaseName[kDICOMStr], stationName[kDICOMStr], softwareVersions[kDICOMStr], deviceSerialNumber[kDICOMStr], institutionName[kDICOMStr], referringPhysicianName[kDICOMStr], instanceUID[kDICOMStr], seriesInstanceUID[kDICOMStr], studyInstanceUID[kDICOMStr], bodyPartExamined[kDICOMStr], procedureStepDescription[kDICOMStr], imageTypeText[kDICOMStr], imageType[kDICOMStr], institutionalDepartmentName[kDICOMStr], manufacturersModelName[kDICOMStr], patientID[kDICOMStr], patientOrient[kDICOMStr], patientName[kDICOMStr], accessionNumber[kDICOMStr], seriesDescription[kDICOMStr], studyID[kDICOMStr], sequenceName[kDICOMStr], protocolName[kDICOMStr],sequenceVariant[kDICOMStr],scanningSequence[kDICOMStr], patientBirthDate[kDICOMStr], patientAge[kDICOMStr],  studyDate[kDICOMStr],studyTime[kDICOMStr], deidentificationMethod[kDICOMStr];
         char deepLearningText[kDICOMStrLarge], scanOptions[kDICOMStrLarge], institutionAddress[kDICOMStrLarge], imageComments[kDICOMStrLarge];
         uint32_t dimensionIndexValues[MAX_NUMBER_OF_DIMENSIONS];
         struct TCSAdata CSA;
         bool isDeepLearning, isVariableFlipAngle, isQuadruped, isRealIsPhaseMapHz, isPrivateCreatorRemap, isHasOverlay, isEPI, isIR, isPartialFourier, isDiffusion, isVectorFromBMatrix, isRawDataStorage, isGrayscaleSoftcopyPresentationState, isStackableSeries, isCoilVaries, isNonParallelSlices, isBVecWorldCoordinates, isSegamiOasis, isXA10A, isScaleOrTEVaries, isScaleVariesEnh, isDerived, isXRay, isMultiEcho, isValid, is3DAcq, is2DAcq, isExplicitVR, isLittleEndian, isPlanarRGB, isSigned, isHasPhase, isHasImaginary, isHasReal, isHasMagnitude,isHasMixed, isFloat, isResampled, isLocalizer;
         char phaseEncodingRC, patientSex;
+        struct TDeIDCodeSequence deID_CS[MAX_DEID_CS];
     };
     struct TDCMprefs {
         int isVerbose, compressFlag, isIgnoreTriggerTimes;

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -1445,6 +1445,24 @@ tse3d: T2*/
 			fprintf(fp, "\t\"NonlinearGradientCorrection\": false,\n");
 	if (d.isDerived) //DICOM is derived image or non-spatial file (sounds, etc)
 		fprintf(fp, "\t\"RawImage\": false,\n");
+	json_Str(fp, "\t\"DeidentificationMethod\": \"%s\",\n", d.deidentificationMethod);
+if(d.deID_CS_n>0)
+{
+	fprintf(fp, "\t\"DeidentificationMethodCodeSequence\": [ \n");
+	for (int i = 0; i < d.deID_CS_n && i < MAX_DEID_CS; i++)
+	{
+		fprintf(fp, "\t  { \n");
+		json_Str(fp, "\t\t\"CodeValue\": \"%s\",\n", d.deID_CS[i].CodeValue);
+		json_Str(fp, "\t\t\"CodingSchemeDesignator\": \"%s\",\n", d.deID_CS[i].CodingSchemeDesignator);
+		json_Str(fp, "\t\t\"CodingSchemeVersion\": \"%s\",\n", d.deID_CS[i].CodingSchemeVersion);
+		json_Str(fp, "\t\t\"CodeMeaning\": \"%s\"\n", d.deID_CS[i].CodeMeaning);
+		if(i+1 < d.deID_CS_n)
+			fprintf(fp, "\t  },\n");
+		else
+			fprintf(fp, "\t  }\n");
+	}
+	fprintf(fp, "\t],\n");
+}
 	if (d.seriesNum > 0)
 		fprintf(fp, "\t\"SeriesNumber\": %ld,\n", d.seriesNum);
 	//Chris Gorgolewski: BIDS standard specifies ISO8601 date-time format (Example: 2016-07-06T12:49:15.679688)


### PR DESCRIPTION
This parallels my PR to bids-specification:
https://github.com/bids-standard/bids-specification/pull/1772
https://github.com/bids-standard/bids-specification/issues/1709

The goal is to add DeidentificationMethod and DeidentificationMethodCodeSequence to json, so that users downstream have a chance to be informed of whether some tags were scrubbed and/or if any de-facing or other image scrubbing was applied.

From our email discussion, I understand that you will probably not merge this until bids-specification merges theirs. I thought we could iterate on this, if needed, in the meantime.

Thanks for your consideration,
Chris Schwarz
Mayo Clinic