### PR TITLE
add MAGNITUDE to ImageType for GE data 

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -1415,6 +1415,8 @@ tse3d: T2*/
 			} else
 				isSep = true;
 		}
+		if ((d.isHasMagnitude) && ((d.manufacturer == kMANUFACTURER_GE) || (strstr(d.imageType, "_MAGNITUDE_") == NULL)))
+			fprintf(fp, "\", \"MAGNITUDE");
 		if ((d.isHasPhase) && ((d.manufacturer == kMANUFACTURER_GE) || (strstr(d.imageType, "_PHASE_") == NULL)))
 			fprintf(fp, "\", \"PHASE"); //"_IMAGINARY_"
 		if ((d.isHasReal) && ((d.manufacturer == kMANUFACTURER_GE) || (strstr(d.imageType, "_REAL_") == NULL)))


### PR DESCRIPTION
That change is necessary for heudiconv logic in `heudiconv.convert.update_complex_name` triggering `RuntimeError("Data type could not be inferred from the metadata.")`.

https://github.com/nipy/heudiconv/blob/68231ef2dc9bfc603c2f925c3ec00c98dd6681b4/heudiconv/convert.py#L334-L340

Otherwise, it would require heudiconv to assume `MAGNITUDE`  by default, while we reliably have that information from the dicoms at the conversion stage.