### PR TITLE
Fix corrupted raw nrrd file output on Windows

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -4266,7 +4266,7 @@ int nii_saveNRRD(char *niiFilename, struct nifti_1_header hdr, unsigned char *im
 		strcat(fname, ".nhdr"); //nrrd or nhdr
 	else
 		strcat(fname, ".nrrd"); //nrrd or nhdr
-	FILE *fp = fopen(fname, "w");
+	FILE *fp = fopen(fname, "wb");
 	fprintf(fp, "NRRD0005\n");
 	fprintf(fp, "# Complete NRRD file format specification at:\n");
 	fprintf(fp, "# http://teem.sourceforge.net/nrrd/format.html\n");


### PR DESCRIPTION
On Windows, when NRRD file was written into .nrrd format with raw pixels then the image was corrupted.

The root cause was that the file was opened in text mode and therefore each 0a byte was converted to 0d0a resulting in an incorrect byte stream.