### PR TITLE
refactor file handling in WASM wrapper

### DIFF
--- a/js/index.html
+++ b/js/index.html
@@ -11,16 +11,90 @@
   <h1>dcm2niix WASM Demo</h1>
   <input type="file" id="fileInput" webkitdirectory multiple>
   <button id="processButton">Process Image</button>
+  <div id="dropTarget" style="margin: 2rem; color: white; width: 100px; height: 100px; background-color: red;">
+    Drop files here
+  </div>
   <p id="status">Please select a dicom folder to process.</p>
   <a id="downloadLink" style="display: none;">Download Processed Image(s)</a>
 
   <script type="module">
     import { Dcm2niix } from './dist/index.js';
-    const dcm2niix = new Dcm2niix();
+
     const fileInput = document.getElementById('fileInput');
     const processButton = document.getElementById('processButton');
     const status = document.getElementById('status');
     const downloadLink = document.getElementById('downloadLink');
+
+    const dropTarget = document.getElementById('dropTarget');
+    dropTarget.addEventListener('dragover', (event) => {
+      event.preventDefault();
+      dropTarget.style.backgroundColor = 'green';
+    });
+
+    dropTarget.addEventListener('dragleave', (event) => {
+      event.preventDefault();
+      dropTarget.style.backgroundColor = 'red';
+    });
+
+    dropTarget.ondrop = handleDrop;
+
+    async function handleDrop(e) {
+      e.preventDefault(); // prevent navigation to open file
+      const items = e.dataTransfer.items;
+      const files = [];
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i].webkitGetAsEntry();
+        if (item) {
+          await traverseFileTree(item, '', files);
+        }
+      }
+      const dcm2niix = new Dcm2niix();
+      await dcm2niix.init()
+      const resultFileList = await dcm2niix.inputFromDropItems(files).run()
+
+      resultFileList.forEach((resultFile, index) => {
+          let url = URL.createObjectURL(resultFile);
+          const downloadLink = document.createElement('a');
+          downloadLink.href = url;
+          downloadLink.download = resultFile.name;
+          downloadLink.textContent = `Download ${resultFile.name}`;
+          downloadLink.style.display = 'block';
+          document.body.appendChild(downloadLink);
+        });
+        status.textContent = 'Processing complete!';
+    }
+
+    async function traverseFileTree(item, path = '', fileArray) {
+      return new Promise((resolve) => {
+        if (item.isFile) {
+          item.file(file => {
+            file.fullPath = path + file.name; 
+            // IMPORTANT: _webkitRelativePath is required for dcm2niix to work.
+            // We need to add this property so we can parse multiple directories correctly.
+            // the "webkitRelativePath" property on File objects is read-only, so we can't set it directly, hence the underscore.
+            file._webkitRelativePath = path + file.name;
+            fileArray.push(file);
+            resolve();
+          });
+        } else if (item.isDirectory) {
+          const dirReader = item.createReader();
+          const readAllEntries = () => {
+            dirReader.readEntries(entries => {
+              if (entries.length > 0) {
+                const promises = [];
+                for (const entry of entries) {
+                  promises.push(traverseFileTree(entry, path + item.name + '/', fileArray));
+                }
+                Promise.all(promises).then(readAllEntries);
+              } else {
+                resolve();
+              }
+            });
+          };
+          readAllEntries();
+        }
+      });
+    }
 
     let selectedFiles = null;
 
@@ -30,26 +104,22 @@
     });
 
     processButton.addEventListener('click', async () => {
-      // if (!selectedFile) return;
-
       status.textContent = 'Processing...';
-      // processButton.disabled = true;
-
       try {
         console.log('Initializing dcm2niix wasm...');
+        const dcm2niix = new Dcm2niix();
         await dcm2niix.init();
         console.log('dcm2niix wasm initialized.');
 
         const t0 = performance.now();
 
         const inputFileList = selectedFiles
-        const resultFileList = await dcm2niix.input(inputFileList).run()        
+        const resultFileList = await dcm2niix.input(inputFileList).run()
         console.log(resultFileList);
 
         const t1 = performance.now();
         console.log("dcm2niix wasm took " + (t1 - t0) + " milliseconds.")
 
-        // Create a download link for each file in resultFileList
         resultFileList.forEach((resultFile, index) => {
           let url = URL.createObjectURL(resultFile);
           const downloadLink = document.createElement('a');

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/dcm2niix",
-  "version": "0.1.1",
+  "version": "0.1.1-dev.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {


### PR DESCRIPTION
This PR refactors the file handling in the JavaScript wrapper to allow similar behaviour when files come from `<input>` html elements using `webkitdirectory` and when files come from users drag and drop events where the files will be from `event.dataTransfer.items`. 

Unfortunately, the latter case requires some custom event handling by the downstream developer to recursively read files from directories. 

We have this same constraint in Niivue, but we attach event handlers directly to the canvas element there. In the case of `dcm2niix`, it does not care about html elements or their events, so that handling has to be taken care of prior to passing files in. 

The changes in this PR make that process slightly less painful though. 

two new methods on the `Dcm2niix` class are available:
- `inputFromWebkitDirectory`
- `inputFromDropItems`
- also: file from `event.dataTransfer.items` (i.e. dropped files) must have the custom property `_webkitRelativePath` appended. 

This all works, and is demonstrated in the live demo here: https://niivue.github.io/niivue-dcm2niix/

and in the demo web app repo here: https://github.com/niivue/niivue-dcm2niix