### PR TITLE
Changes from divest 1.1

### DIFF
--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -8008,10 +8008,10 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 				mxIdx = i;
 			}
 			if (isVerbose > 1)
-				printf("slice %d is %gmm from isocenter\n", i, dx);
+				printMessage("slice %d is %gmm from isocenter\n", i, dx);
 		}
 		if (isVerbose > 1)
-			printf("slice %d is furthest (%gmm) from isocenter\n", mxIdx, mxDx);
+			printMessage("slice %d is furthest (%gmm) from isocenter\n", mxIdx, mxDx);
 		// second pass: measure each slices scalar distance from furthest slice
 		// ensure their are no repeated slice positions
 		fidx *objects = (fidx *)malloc(sizeof(struct fidx) * numDimensionIndexValues);
@@ -8019,7 +8019,7 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 		for (int i = 0; i < numDimensionIndexValues; i++) {
 			float dx = sqrt(pow(patientPosition1[i] - patientPosition1[mxIdx], 2) + pow(patientPosition2[i] - patientPosition2[mxIdx], 2) + pow(patientPosition3[i] - patientPosition3[mxIdx], 2));
 			if (isVerbose > 1)
-				printf("slice %d is %gmm from furthest slice\n", i, dx);
+				printMessage("slice %d is %gmm from furthest slice\n", i, dx);
 			objects[i].value = dx;
 			// sliceMM[i];
 			objects[i].index = i;

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -3963,7 +3963,7 @@ void clear_volume(struct TVolumeDiffusion *ptvd) {
 	ptvd->_dtiV[0] = -1;
 	for (int i = 1; i < 4; ++i)
 		ptvd->_dtiV[i] = 2;
-	for (int i = 1; i < 6; ++i)
+	for (int i = 0; i < 6; ++i)
 		ptvd->_symBMatrix[i] = NAN;
 	// numDti = 0;
 } // clear_volume()
@@ -4254,6 +4254,13 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 	dti4D->frameReferenceTime[0] = -1;
 	// dti4D->fragmentOffset[0] = -1;
 	dti4D->intenScale[0] = 0.0;
+#ifdef USING_R
+	// Ensure dti4D fields are initialised, as in nii_readParRec()
+	for (int i = 0; i < kMaxDTI4D; i++) {
+		dti4D->S[i].V[0] = -1.0;
+		dti4D->TE[i] = -1.0;
+	}
+#endif
 	d.deID_CS_n = 0;
 	struct TVolumeDiffusion volDiffusion = initTVolumeDiffusion(&d, dti4D);
 	struct stat s;
@@ -7432,7 +7439,7 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 			// LO array of floats stored in LONG STRING!
 			//  [960.5\400\17.9108\0\-9999\-9999]
 			// we want 3rd value, e.g. 17.9:
-			float v[5];
+			float v[6];
 			dcmMultiFloat(lLength, (char *)&buffer[lPos], 5, v);
 			d.CSA.tablePos[3] = v[3] - tableDeltaGE;
 			d.CSA.tablePos[0] = 1.0;

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -26,9 +26,9 @@
 #else
 #undef MiniZ
 #endif
+#include "tinydir.h"
 #include "nifti1_io_core.h"
 #include "print.h"
-#include "tinydir.h"
 #ifndef USING_R
 #include "nifti1.h"
 #endif
@@ -3678,7 +3678,9 @@ int nii_createFilename(struct TDICOMdata dcm, char *niiFilename, struct TDCMopts
 					strcat(bidsSubject, "1");
 				else
 					strcat(bidsSubject, opts.bidsSubject);
+#ifndef USING_R
 				printf("%s<<<:::\n", bidsSubject);
+#endif
 				char bidsSession[kOptsStr] = "ses-";
 				if (strlen(opts.bidsSession) <= 0)
 					strcat(bidsSession, "1");
@@ -7098,7 +7100,7 @@ void setBidsSiemens(struct TDICOMdata *d, int nConvert, int isVerbose, const cha
 		strcat(suffixBIDS, modalityBIDS);
 	}
 	if ((isVerbose > 0) || (strlen(dataTypeBIDS) < 1))
-		printf("::autoBids:Siemens CSAseqFname:'%s' pulseSeq:'%s' seqName:'%s'\n",
+		printMessage("::autoBids:Siemens CSAseqFname:'%s' pulseSeq:'%s' seqName:'%s'\n",
 			   seqDetails, d->pulseSequenceName, d->sequenceName);
 	if (isDerived)
 		strcpy(dataTypeBIDS, "derived");
@@ -8845,8 +8847,12 @@ int saveDcm2Nii(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata dcmLi
 	// issue867 TODO sizeof(TDTI4D) = 10mb, this could be reduced if elements reduced from kMaxDTI4D
 	TDTI4D *dti4Ds = (TDTI4D *)malloc(sizeof(TDTI4D));
 	if (dti4Ds == NULL) {
+#ifdef USING_R
+		Rf_error("Failed to allocate memory for dti4Ds");
+#else
 		perror("Failed to allocate memory for dti4Ds");
 		exit(EXIT_FAILURE);
+#endif
 	}
 	// Copy the content from the original dti4D into dti4Ds
 	*dti4Ds = *dti4D;


### PR DESCRIPTION
Changes to the core codebase incorporated into `divest` 1.1, both for R compatibility and to address various runtime issues identified by `clang` ASan/UBSan and `valgrind`. One of the latter fixes is fenced using `USING_R`, as I'm not totally confident that it's the right change in the right place.