### PR TITLE
add zlib to wasm compile command and bump version

### DIFF
--- a/console/makefile
+++ b/console/makefile
@@ -59,6 +59,6 @@ noroi:
 	g++ $(CFLAGS) -I. $(JSFLAGS) $(JFLAGS) $(LFLAGS) $(UFILES) -DmyNoRois
 
 wasm:
-	emcc -O3 $(UFILES) -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["callMain", "ccall", "cwrap", "FS", "FS_createDataFile", "FS_readFile", "FS_unlink", "allocateUTF8", "getValue", "stringToUTF8", "setValue"]' -s STACK_OVERFLOW_CHECK=2 -s STACK_SIZE=16MB -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_main", "_malloc", "_free"]' -s FORCE_FILESYSTEM=1 -s INVOKE_RUN=0 -o ../js/src/dcm2niix.js
+	emcc -O3 $(UFILES) -lz -s USE_ZLIB -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["callMain", "ccall", "cwrap", "FS", "FS_createDataFile", "FS_readFile", "FS_unlink", "allocateUTF8", "getValue", "stringToUTF8", "setValue"]' -s STACK_OVERFLOW_CHECK=2 -s STACK_SIZE=16MB -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_main", "_malloc", "_free"]' -s FORCE_FILESYSTEM=1 -s INVOKE_RUN=0 -o ../js/src/dcm2niix.js
 	# STACK_SIZE=16MB is the minimum value found to work with the current codebase when targeting WASM
 

--- a/js/index.html
+++ b/js/index.html
@@ -114,7 +114,7 @@
         const t0 = performance.now();
 
         const inputFileList = selectedFiles
-        const resultFileList = await dcm2niix.input(inputFileList).run()
+        const resultFileList = await dcm2niix.input(inputFileList).z('y').run()
         console.log(resultFileList);
 
         const t1 = performance.now();

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@niivue/dcm2niix",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@niivue/dcm2niix",
-      "version": "0.1.1",
+      "version": "1.0.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "esbuild": "^0.23.1"

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@niivue/dcm2niix",
-  "version": "0.1.1-dev.2",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {


### PR DESCRIPTION
This PR adds zlib to the `emcc` compile command for the `wasm` target. Now the wasm module can produce `.nii.gz` files if requested. However, this is quite a bit slower in my limited testing. 