### PR TITLE
PyPi release

### DIFF
--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -50,7 +50,7 @@ extern "C" {
 #define kCPUsuf " " // unknown CPU
 #endif
 
-#define kDCMdate "v1.0.20241208"
+#define kDCMdate "v1.0.20241211"
 #define kDCMvers kDCMdate " " kJP2suf kLSsuf kCCsuf kCPUsuf
 
 static const int kMaxEPI3D = 1024; // maximum number of EPI images in Siemens Mosaic


### PR DESCRIPTION
Attempt to live within [PyPi](https://github.com/pypi/support/issues/5269#issuecomment-2543234406) limits by disabling `submodules: recursive` from release.yml