### PR TITLE
Re-add zlib support and enable jpegls support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ __pycache__/
 
 dist
 node_modules
-dcm2niix.js
-dcm2niix.wasm
+dcm2niix*.js
+dcm2niix*.wasm

--- a/console/makefile
+++ b/console/makefile
@@ -69,6 +69,10 @@ noroi:
 	g++ $(CFLAGS) -I. $(JSFLAGS) $(JFLAGS) $(LFLAGS) $(UFILES) -DmyNoRois
 
 wasm:
-	emcc -O3 $(UFILES) -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["callMain", "ccall", "cwrap", "FS", "FS_createDataFile", "FS_readFile", "FS_unlink", "allocateUTF8", "getValue", "stringToUTF8", "setValue"]' -s STACK_OVERFLOW_CHECK=2 -s STACK_SIZE=16MB -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_main", "_malloc", "_free"]' -s FORCE_FILESYSTEM=1 -s INVOKE_RUN=0 -o ../js/src/dcm2niix.js
+	emcc -O3 $(UFILES) -lz -s USE_ZLIB -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["callMain", "ccall", "cwrap", "FS", "FS_createDataFile", "FS_readFile", "FS_unlink", "allocateUTF8", "getValue", "stringToUTF8", "setValue"]' -s STACK_OVERFLOW_CHECK=2 -s STACK_SIZE=16MB -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_main", "_malloc", "_free"]' -s FORCE_FILESYSTEM=1 -s INVOKE_RUN=0 -o ../js/src/dcm2niix.js
+	# STACK_SIZE=16MB is the minimum value found to work with the current codebase when targeting WASM
+
+wasm-jpegls:
+	emcc -O3 $(JFLAGS) $(UFILES) -lz -s USE_ZLIB -s DEMANGLE_SUPPORT=1 -s EXPORTED_RUNTIME_METHODS='["callMain", "ccall", "cwrap", "FS", "FS_createDataFile", "FS_readFile", "FS_unlink", "allocateUTF8", "getValue", "stringToUTF8", "setValue"]' -s STACK_OVERFLOW_CHECK=2 -s STACK_SIZE=16MB -s ALLOW_MEMORY_GROWTH=1 -s WASM=1 -s EXPORT_ES6=1 -s MODULARIZE=1 -s EXPORTED_FUNCTIONS='["_main", "_malloc", "_free"]' -s FORCE_FILESYSTEM=1 -s INVOKE_RUN=0 -o ../js/src/dcm2niix.jpegls.js
 	# STACK_SIZE=16MB is the minimum value found to work with the current codebase when targeting WASM
 

--- a/js/esbuild.config.jpegls.js
+++ b/js/esbuild.config.jpegls.js
@@ -1,0 +1,24 @@
+const esbuild = require('esbuild');
+const fs = require('fs');
+
+esbuild.build({
+  entryPoints: ['./src/index.jpegls.js'],
+  outfile: './dist/index.jpegls.js',
+  bundle: true,
+  format: 'esm',
+  target: ['es2020'],
+  minify: false,
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
+}).then(() => {
+  // copy worker.js, dcm2niix.wasm, dcm2niix.js to dist folder
+  // (they do not require any processing by esbuild).
+  // Technically, none of the files in the src folder require processing by esbuild, 
+  // but it does allow minification (optional), and ES version target specification if needed.
+  // In the future, if we use Typescript, we can use esbuild to transpile the Typescript to JS.
+  fs.copyFileSync('./src/worker.jpegls.js', './dist/worker.jpegls.js');
+  fs.copyFileSync('./src/dcm2niix.jpegls.wasm', './dist/dcm2niix.jpegls.wasm');
+  fs.copyFileSync('./src/dcm2niix.jpegls.js', './dist/dcm2niix.jpegls.js');
+  console.log('Build completed!');
+}).catch(() => process.exit(1));

--- a/js/index.html
+++ b/js/index.html
@@ -19,6 +19,8 @@
 
   <script type="module">
     import { Dcm2niix } from './dist/index.js';
+    // use below line for jpegls version
+    // import { Dcm2niix } from './dist/index.jpegls.js';
 
     const fileInput = document.getElementById('fileInput');
     const processButton = document.getElementById('processButton');

--- a/js/package.json
+++ b/js/package.json
@@ -1,18 +1,24 @@
 {
   "name": "@niivue/dcm2niix",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "exports": {
     ".": {
       "import": "./dist/index.js"
+    },
+    "./with-jpegls": {
+      "import": "./dist/index.jpegls.js"
     }
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "node esbuild.config.js",
+    "build": "node esbuild.config.js && node esbuild.config.jpegls.js",
     "makeWasm": "make wasm -C ../console",
-    "prebuild": "npm run makeWasm && node scripts/pre-build.js -i src/dcm2niix.js -o src/dcm2niix.js",
+    "makeWasmJpegls": "JPEGLS=1 make wasm-jpegls -C ../console",
+    "fixWasmJs": "node scripts/pre-build.js -i src/dcm2niix.js -o src/dcm2niix.js",
+    "fixWasmJsJpegls": "node scripts/pre-build.js -i src/dcm2niix.jpegls.js -o src/dcm2niix.jpegls.js",
+    "prebuild": "npm run makeWasm && npm run makeWasmJpegls && npm run fixWasmJs && npm run fixWasmJsJpegls",
     "demo": "npm run build && npx http-server .",
     "pub": "npm run build && npm publish --access public"
   },

--- a/js/src/index.jpegls.js
+++ b/js/src/index.jpegls.js
@@ -1,0 +1,315 @@
+export class Dcm2niix {
+  constructor() {
+    this.worker = null;
+  }
+
+  init() {
+    this.worker = new Worker(new URL('./worker.jpegls.js', import.meta.url), { type: 'module' });
+    return new Promise((resolve, reject) => {
+      // handle worker ready message.
+      // This gets reassigned in the run() method, 
+      // but we need to handle the ready message before that.
+      // Maybe there is a less hacky way to do this?
+      this.worker.onmessage = (event) => {
+        if (event.data && event.data.type === 'ready') {
+          resolve(true); // Resolve the promise when the worker is ready
+        }
+      }
+
+      // Handle worker init errors.
+      this.worker.onerror = (error) => {
+        reject(new Error(`Worker failed to load: ${error.message}`));
+      }
+    });
+  }
+
+  conformFileList(fileObjectOrArray) {
+    // prepare files with their relative paths.
+      // annoyingly, safari strips the webkitRelativePath property when sending files to the worker.
+      // fileList is a FileList object, not an array, so we need to convert it to an array.
+      // filesWithRelativePaths is an array of objects with the file and webkitRelativePath properties.
+      // Now we can use the webkitRelativePath property in the worker.
+      // This is important for dcm2niix to work with nested dicom directories in safari.
+      const filesWithRelativePaths = Array.from(fileObjectOrArray).map((file) => ({
+        file,
+        // need to check for both webkitRelativePath and _webkitRelativePath.
+        // _webkitRelativePath is used in case the file was not from a webkitdirectory file input element (e.g. from a drop event).
+        // IMPORTANT: it is up to other developers to ensure that the special _webkitRelativePath property is set correctly when using drop events.
+        webkitRelativePath: file.webkitRelativePath || file._webkitRelativePath || ''
+      }));
+      return filesWithRelativePaths
+    }
+
+  input(fileListObject) {
+    const conformedFileList = this.conformFileList(fileListObject);
+    return new Processor({ worker: this.worker, fileList: conformedFileList });
+  }
+
+  inputFromWebkitDirectory(fileListObject) {
+    const conformedFileList = this.conformFileList(fileListObject);
+    return new Processor({ worker: this.worker, fileList: conformedFileList });
+  }
+
+  inputFromDropItems(dataTransferItemArray) {
+    const conformedFileList = this.conformFileList(dataTransferItemArray);
+    return new Processor({ worker: this.worker, fileList: conformedFileList });
+  }
+}
+
+class Processor {
+  constructor({ worker, fileList }) {
+    this.worker = worker;
+    this.fileList = fileList;
+    this.commands = []; // default to verbose output for testing
+  }
+
+  _addCommand(cmd, ...args) {
+    this.commands.push(cmd, ...args.map(String));
+    return this;
+  }
+
+  // --version
+  version() {
+    return this._addCommand('--version');
+  }
+
+  // -1..-9 gz compression level (1=fastest..9=smallest, default 6)
+  compressionLevel(level) {
+    return this._addCommand(`-${level}`);
+  }
+
+  // -a adjacent DICOMs (images from same series always in same folder) for faster conversion (n/y, default n)
+  a(value) {
+    return this._addCommand('-a', value);
+  }
+  // alias for -a
+  adjacent(value) {
+    return this.a(value);
+  }
+
+  // -b BIDS sidecar (y/n/o [o=only: no NIfTI], default y)
+  b(value) {
+    return this._addCommand('-b', value);
+  }
+  // alias for -b
+  bids(value) {
+    return this.b(value);
+  }
+
+  // -ba BIDS anonymize (y/n, default y)
+  ba(value) {
+    return this._addCommand('-ba', value);
+  }
+  // alias for -ba
+  bidsAnonymize(value) {
+    return this.ba(value);
+  }
+
+  // -c comment stored as NIfTI aux_file (up to 24 characters)
+  c(value) {
+    return this._addCommand('-c', value);
+  }
+  // alias for -c
+  comment(value) {
+    return this.c(value);
+  }
+
+  // -d directory search depth (0..9, default 5)
+  // Note: not used in browser/wasm since file list is a flat list
+  d(value) {
+    return this._addCommand('-d', value);
+  }
+  // alias for -d
+  directorySearchDepth(value) {
+    return this.d(value);
+  }
+
+  // export as NRRD (y) or MGH (o) or JSON/JNIfTI (j) or BJNIfTI (b) instead of NIfTI (y/n/o/j/b, default n)
+  e(value) {
+    return this._addCommand('-e', value);
+  }
+  // alias for -e
+  exportFormat(value) {
+    return this.e(value);
+  }
+
+  // -f : filename (%a=antenna (coil) name, %b=basename, %c=comments, %d=description, 
+  // %e=echo number, %f=folder name, %g=accession number, %i=ID of patient, %j=seriesInstanceUID, 
+  // %k=studyInstanceUID, %m=manufacturer, %n=name of patient, %o=mediaObjectInstanceUID, 
+  // %p=protocol, %r=instance number, %s=series number, %t=time, %u=acquisition number, 
+  // %v=vendor, %x=study ID; %z=sequence name; 
+  // 
+  // default '%f_%p_%t_%s')
+  f(value) {
+    return this._addCommand('-f', value);
+  }
+  // alias for -f
+  filenameformat(value) {
+    return this.f(value);
+  }
+
+  // -i : ignore derived, localizer and 2D images (y/n, default n)
+  i(value) {
+    return this._addCommand('-i', value);
+  }
+  // alias for -i
+  ignoreDerived(value) {
+    return this.i(value);
+  }
+
+  // -l : losslessly scale 16-bit integers to use dynamic range (y/n/o [yes=scale, no=no, but uint16->int16, o=original], default o)
+  l(value) {
+    return this._addCommand('-l', value);
+  }
+  // alias for -l
+  losslessScale(value) {
+    return this.l(value);
+  }
+
+  // -m : merge 2D slices from same series regardless of echo, exposure, etc. (n/y or 0/1/2, default 2) [no, yes, auto]
+  m(value) {
+    return this._addCommand('-m', value);
+  }
+  // alias for -m
+  merge2DSlices(value) {
+    return this.m(value);
+  }
+
+  // -n : only convert this series CRC number - can be used up to 16 times (default convert all)
+  n(value) {
+    return this._addCommand('-n', value);
+  }
+  // alias for -n
+  seriesCRC(value) {
+    return this.n(value);
+  }
+
+  // -o : output directory (omit to save to input folder)
+  // o(value){
+  //   return this._addCommand('-o', value);
+  // }
+  // alias for -o
+  // outputDirectory(value){
+  //   return this.o(value);
+  // }
+
+  // -p : Philips precise float (not display) scaling (y/n, default y)
+  p(value) {
+    return this._addCommand('-p', value);
+  }
+  // alias for -p
+  philipsPreciseFloat(value) {
+    return this.p(value);
+  }
+
+  // -q : only search directory for DICOMs (y/l/n, default y) [y=show number of DICOMs found, l=additionally list DICOMs found, n=no]
+  q(value) {
+    return this._addCommand('-q', value);
+  }
+  // alias for -q
+  searchDirectory(value) {
+    return this.q(value);
+  }
+
+  // -r : rename instead of convert DICOMs (y/n, default n)
+  r(value) {
+    return this._addCommand('-r', value);
+  }
+  // alias for -r
+  renameOnly(value) {
+    return this.r(value);
+  }
+
+  // -s : single file mode, do not convert other images in folder (y/n, default n)
+  s(value) {
+    return this._addCommand('-s', value);
+  }
+  // alias for -s
+  singleFileMode(value) {
+    return this.s(value);
+  }
+
+  // -v : verbose (n/y or 0/1/2, default 0) [no, yes, logorrheic]
+  v(value) {
+    return this._addCommand('-v', value);
+  }
+  // alias for -v
+  verbose(value) {
+    return this.v(value);
+  }
+
+  // -w : write behavior for name conflicts (0,1,2, default 2: 0=skip duplicates, 1=overwrite, 2=add suffix)
+  w(value) {
+    return this._addCommand('-w', value);
+  }
+  // alias for -w
+  writeBehavior(value) {
+    return this.w(value);
+  }
+
+  // -x : crop 3D acquisitions (y/n/i, default n, use 'i'gnore to neither crop nor rotate 3D acquisitions)
+  x(value) {
+    return this._addCommand('-x', value);
+  }
+  // alias for -x
+  crop(value) {
+    return this.x(value);
+  }
+
+  // -z : gz compress images (y/o/i/n/3, default n) [y=pigz, o=optimal pigz, i=internal:miniz, n=no, 3=no,3D]
+  z(value) {
+    return this._addCommand('-z', value);
+  }
+  // alias for -z
+  gzip(value) {
+    return this.z(value);
+  }
+
+  // --big-endian : byte order (y/n/o, default o) [y=big-end, n=little-end, o=optimal/native]
+  bigEndian(value) {
+    return this._addCommand('--big-endian', value);
+  }
+
+  // --ignore_trigger_times : disregard values in 0018,1060 and 0020,9153
+  ignoreTriggerTimes() {
+    return this._addCommand('--ignore_trigger_times');
+  }
+
+  // --terse : omit filename post-fixes (can cause overwrites)
+  terse() {
+    return this._addCommand('--terse');
+  }
+
+  // --xml : Slicer format features
+  xml() {
+    return this._addCommand('--xml');
+  }
+
+  async run() {
+    return new Promise((resolve, reject) => {
+      this.worker.onmessage = (e) => {
+        if (e.data.type === 'error') {
+          reject(new Error(e.data.message));
+        } else {
+          // get the output file and the exit code from niimath wasm
+          const { convertedFiles, exitCode } = e.data;
+          // --version gives exit code 3 in dcm2niix CLI and wasm
+          if (exitCode === 0 || exitCode === 3) {
+            // success
+            resolve(convertedFiles);
+          } else {
+            // error
+            reject(new Error(`dcm2niix processing failed with exit code ${exitCode}`));
+          }
+        }
+      };
+
+      const args = [...this.commands];
+      if (this.worker === null) {
+        reject(new Error('Worker not initialized. Did you await the init() method?'));
+      }
+      // send files and commands to the worker
+      this.worker.postMessage({ fileList: this.fileList, cmd: args });
+    });
+  }
+}

--- a/js/src/worker.jpegls.js
+++ b/js/src/worker.jpegls.js
@@ -1,0 +1,163 @@
+// Load the Emscripten-generated JavaScript, which will handle the WASM binary loading.
+// The worker is of type "module" so that it can use ES6 module syntax.
+// Importantly, the emscripten code must be compiled with: -s EXPORT_ES6=1 -s MODULARIZE=1.
+// This allows proper module bundlers to import the worker and wasm properly with code splitting. 
+import Module from './dcm2niix.jpegls.js';
+
+// initialise an instance of the Emscripten Module so that
+// it is ready when the worker receives a message.
+// We keep a reference to the module so that the worker can reuse it 
+// for all subsequent calls without having to reinitialise it (which could be slow due to the WASM loading)
+let mod = null
+Module().then((initializedMod) => {
+  mod = initializedMod
+  // Send a ready message once initialization is complete
+  // so we can signal to the main thread that the worker is ready.
+  // The Niimath.init() method will wait for this message before resolving the promise.
+  self.postMessage({ type: 'ready' });
+})
+
+// error handler in the worker
+self.onerror = (message, error) => {
+  self.postMessage({ type: 'error', message: message, error: error ? error.stack : null });
+};
+// unhandled promise rejection handler in the worker
+self.onunhandledrejection = (event) => {
+  self.postMessage({ type: 'error', message: event.reason ? event.reason.message : 'Unhandled rejection', error: event.reason ? event.reason.stack : null });
+};
+
+// copy the files to the emscripten filesystem
+const copyFilesToFS = async (fileList, inDir, outDir) => {
+  // create a directory for dcm2niix to use as its input
+  mod.FS.mkdir(inDir);
+
+  // create a directory for dcm2niix to use as its output
+  mod.FS.mkdir(outDir);
+
+  // an array to hold all the promises for copying files
+  const promises = [];
+  for (let fileItem of fileList) {
+    const file = fileItem.file;
+    // Note: Safari strips webkitRelativePath in the worker,
+    // so we use the name property of the file object instead.
+    const webkitRelativePath = fileItem.webkitRelativePath || file.name;
+    const promise = new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          const data = new Uint8Array(e.target.result);
+          // webkitRelativePath has the file directory and filename separated by '/',
+          // such as 'some_dir/some_file.dcm'.
+          // We need to replace the '/' with '_' to create a valid name for the WASM filesystem
+          // since some_dir does not exist at out mount point. That directory stub, 
+          // doesn't provide any useful information to dcm2niix anyway. 
+          const fileName = `${webkitRelativePath.split('/').join('_')}`;
+          mod.FS.createDataFile(inDir, fileName, data, true, true);
+          resolve(); // Resolve the promise when the file is successfully written
+        } catch (error) {
+          console.error(error);
+          reject(error); // Reject the promise if there's an error
+        }
+      };
+      reader.onerror = () => {
+        console.error(reader.error);
+        reject(reader.error); // Reject the promise if there's an error reading the file
+      };
+      reader.readAsArrayBuffer(file);
+    });
+
+    promises.push(promise);
+  }
+
+  // return a promise that resolves when all files are written
+  return Promise.all(promises);
+
+}
+
+const typeFromExtension = (fileName) => {
+  const ext = fileName.split('.').pop();
+  switch (ext) {
+    case 'nii':
+      return 'application/sla';
+    case 'json':
+      return 'application/json';
+    case 'txt':
+      return 'text/plain';
+    case 'gz':
+      return 'application/gzip';
+    case 'bvec':
+      return 'text/plain';
+    case 'bval':
+      return 'text/plain';
+    case 'nrrd':
+      return 'application/octet-stream';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+const handleMessage = async (e) => {
+  try {
+    // name the input and output directories that will get created.
+    const inDir = '/input';
+    const outDir = '/output';
+    const fileList = e.data.fileList;
+    const args = e.data.cmd;
+    // always put ['-o', outDir] at the beginning of the args array.
+    // The user does not need to specify the output directory since it 
+    // will be a temporary directory that gets created by the worker in the emscripten filesystem.
+    args.unshift('-o', outDir);
+
+    if (!fileList || args.length < 1) {
+      throw new Error("Expected a flat file list and at least one command");
+    }
+
+    if (!Array.isArray(args)) {
+      throw new Error("Expected args to be an array");
+    }
+
+    if (!mod) {
+      throw new Error("WASM module not loaded yet!");
+    }
+
+
+    // copy the files to the emscripten filesystem
+    await copyFilesToFS(fileList, inDir, outDir);
+   
+    // then add the input directory at the end of the args array
+    args.push(inDir);
+    // call the main function of the WASM module with the args
+    const exitCode = mod.callMain(args);
+
+    // read all files from outDir and return them
+    const files = mod.FS.readdir(outDir);
+    // filter out any file from the files array that starts 
+    // with a dot. FS.readdir returns '.' and '..' which is not useful.
+    const filteredFiles = files.filter(file => !file.startsWith('.'));
+    
+    const convertedFiles = [];
+    for (let file of filteredFiles) {
+      const filePath = outDir + '/' + file;
+      // const blob = new Blob([mod.FS.readFile(filePath)], { type: 'application/sla' });
+      // make a file Object from the return value of readFile
+      const fileData = mod.FS.readFile(filePath);
+      const f = new File([fileData], file, { type: typeFromExtension(file) });
+      convertedFiles.push(f);
+    }
+
+    // send a message back to the main thread with the output file, exit code and output file name
+    self.postMessage({ convertedFiles: convertedFiles, exitCode: exitCode });
+
+    // --------- only for version test
+    // const exitCode = mod.callMain(args);
+    // // send a message back to the main thread with the output file, exit code and output file name
+    // // self.postMessage({ blob: outputFile, outName: outName, exitCode: exitCode });
+    // self.postMessage({ blob: "blob", exitCode: exitCode });
+  } catch (err) {
+    // Send error details back to the main thread
+    self.postMessage({ type: 'error', message: err.message, error: err.stack });
+  }
+}
+
+// Handle messages from the main thread
+self.addEventListener('message', handleMessage, false);


### PR DESCRIPTION
@neurolabusc , the development branch seems to have lost my changes that enabled WASM zlib support. The NPM package that is published has this support, but the make file in the repo was clobbered somehow. 

I have:
- enabled WASM zlib support in the wasm target again
- enabled jpegls support in the new wasm-jpegls target
- updated the npm package build to export both the jpegls and non-jpegls builds

Developers using `@niivue/dcm2niix` can choose which build they want to import into their apps by using one of the following:

### Default, without jpegls
```
import { Dcm2niix } from '@niivue/dcm2niix' // default, and without jpegls
// Chris Rorden's dcm2niiX version v1.0.20241231  Clang20.0.0
```

### With jpegls
```
import { Dcm2niix } from '@niivue/dcm2niix/with-jpegls'
// Chris Rorden's dcm2niiX version v1.0.20241231  (JP-LS:CharLS) Clang20.0.0
```


