### PR TITLE
DCM2NIIXFSLIB changes

### DIFF
--- a/console/dcm2niix_fswrapper.h
+++ b/console/dcm2niix_fswrapper.h
@@ -23,16 +23,25 @@ class dcm2niix_fswrapper {
 
 	// interface to nii_loadDirCore() to search all dicom files from the directory input file is in,
 	// and convert dicom files with the same series as given file.
-	static int dcm2NiiOneSeries(const char *dcmfile);
+	static int dcm2NiiOneSeries(const char *dcmfile, bool convert=true);
 
-	// interface to nii_getMrifsStruct()
+        // interface to singleDICOM() to convert only the single image provided
+        static int dcm2NiiSingleFile(const char* dcmfile);
+
+	// interface to nii_dicom_batch.cpp::nii_getMrifsStruct()
 	static MRIFSSTRUCT *getMrifsStruct(void);
+
+        // interface to nii_dicom_batch.cpp::nii_clrMrifsStruct()
+        static void clrMrifsStruct(void);
 
 	// return nifti header saved in MRIFSSTRUCT
 	static nifti_1_header *getNiiHeader(void);
 
-	// interface to nii_getMrifsStructVector()
+	// interface to nii_dicom_batch.cpp::nii_getMrifsStructVector()
 	static std::vector<MRIFSSTRUCT> *getMrifsStructVector(void);
+
+        // interface to nii_dicom_batch.cpp::nii_clrMrifsStructVector()
+        static void clrMrifsStructVector(void);
 
 	// return image data saved in MRIFSSTRUCT
 	static const unsigned char *getMRIimg(void);

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -96,6 +96,7 @@ void readIniFile(struct TDCMopts *opts, const char *argv[]);
 int nii_saveNIIx(char *niiFilename, struct nifti_1_header hdr, unsigned char *im, struct TDCMopts opts);
 int nii_loadDir(struct TDCMopts *opts);
 int nii_loadDirCore(char *indir, struct TDCMopts *opts);
+int singleDICOM(struct TDCMopts *opts, char *fname);
 void nii_SaveBIDS(char pathoutname[], struct TDICOMdata d, struct TDCMopts opts, struct nifti_1_header *h, const char *filename);
 int nii_createFilename(struct TDICOMdata dcm, char *niiFilename, struct TDCMopts opts);
 void nii_createDummyFilename(char *niiFilename, struct TDCMopts opts);


### PR DESCRIPTION
  1. freesurfer commit f34ac43, Feb 05, 2025 
      - support single dicom file conversion
  2. freesurfer commit 02f92cc, Apr 02, 2024
     - save bvals/bvecs for B=0 series in mrifsStruct
  3. freesurfer commit f81e10c, Apr 02, 2024 
     - add optional 'bool convert' parameter to dcm2niix_fswrapper::dcm2NiiOneSeries() if 'convert=false', retrieve dicom info only 
     - add dcm2niix_fswrapper::clrMrifsStruct() to interface nii_dicom_batch.cpp::nii_clrMrifsStruct() 
     - add dcm2niix_fswrapper::clrMrifsStructVector() to interface nii_dicom_batch.cpp::nii_clrMrifsStructVector() 
     - fix nii_dicom_batch.cpp::dcmListDump() to not accidentally close stdout