### PR TITLE
Add higher bound to CMake policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
-
-if(COMMAND CMAKE_POLICY)
-    CMAKE_POLICY(SET CMP0003 NEW)
-endif()
+cmake_minimum_required(VERSION 3.5...4.0)
 
 project(dcm2niix)
 

--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...4.0)
 
 project(console)
 


### PR DESCRIPTION
This would make future downstream maintenance simpler, i.e. it is indicating we have tested this with CMake (policies) up to version 4.0.