### PR TITLE
Update scikit-build-core to 0.11, without pyproject extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools_scm>=7", "scikit-build-core[pyproject]>=0.5"]
+requires = ["setuptools_scm>=7", "scikit-build-core>=0.11"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
In https://github.com/scikit-build/scikit-build-core/commit/b3b955e4a20fe080980cf17c64ff57d6a2768626, `scikit-build-core` eliminated the `pyproject` extra. Stop asking for it, and let the minimum version of `scikit-build-core` be one that does not have a `pyproject` extra.