### PR TITLE
InversionTime missing from json sidecar for Philips R11

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ The following tools exploit dcm2niix
   - [BOLD5000_autoencoder](https://github.com/nmningmei/BOLD5000_autoencoder) uses dcm2niix to pipe imaging data into an unsupervised machine learning algorithm.
   - [boutiques-dcm2niix](https://github.com/lalet/boutiques-dcm2niix) is a dockerfile for installing and validating dcm2niix.
   - [Brain imAgiNg Analysis iN Arcana (Banana)](https://pypi.org/project/banana/) is a collection of brain imaging analysis workflows, it uses dcm2niix for format conversions.
+  - [Brain Lesion Suite](https://github.com/BrainLesion) supports dcm2niix for DICOM to NifTI conversion.
   - [brainnetome DiffusionKit](http://diffusion.brainnetome.org/en/latest/) uses dcm2niix to convert images.
   - [BraTS-Preprocessor](https://neuronflow.github.io/BraTS-Preprocessor/) uses dcm2niix to import files for [Brain Tumor Segmentation](https://www.frontiersin.org/articles/10.3389/fnins.2020.00125/full).
   - [CardioNIfTI](https://github.com/UK-Digital-Heart-Project/CardioNIfTI) processes cardiac MR DICOM datasets and converts them to NIfTI.

--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 if(BUILD_DCM2NIIXFSLIB)
     set(DCM2NIIXFSLIB dcm2niixfs)
     # BUILD_DCM2NIIXFSLIB and USE_TURBOJPEG are not allowed to be enabled at
-    # the same time, so ujpeg.cpp is unconditionaly in this sources list:
+    # the same time, so ujpeg.cpp is unconditionally in this sources list:
     set(DCM2NIIXFSLIB_SRCS
         dcm2niix_fswrapper.cpp
         nii_dicom.cpp

--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -59,11 +59,11 @@ if(UNIX)
     if(ARM_CRC)
         # wrong answer for Apple Silicon: check_cxx_compiler_flag(-msse2 HAS_SSE2)
     else()
-	    check_cxx_compiler_flag(-msse2 HAS_SSE2)
-	    if(HAS_SSE2)
-	        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse")
-	    endif()
-	endif()
+      check_cxx_compiler_flag(-msse2 HAS_SSE2)
+      if(HAS_SSE2)
+          set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse2 -mfpmath=sse")
+      endif()
+  endif()
 endif()
 
 set(PROGRAMS dcm2niix)
@@ -86,12 +86,14 @@ set(DCM2NIIX_SRCS
     main_console.cpp
     nii_dicom.cpp
     jpg_0XC3.cpp
-    ujpeg.cpp
     nifti1_io_core.cpp
     nii_foreign.cpp
     nii_ortho.cpp
     nii_dicom_batch.cpp)
 
+if(NOT USE_TURBOJPEG)
+    set(DCM2NIIX_SRCS ${DCM2NIIX_SRCS} ujpeg.cpp)
+endif()
 
 option(USE_JNIFTI "Build with JNIfTI support" ON)
 if(USE_JNIFTI)
@@ -101,6 +103,8 @@ endif()
 
 if(BUILD_DCM2NIIXFSLIB)
     set(DCM2NIIXFSLIB dcm2niixfs)
+    # BUILD_DCM2NIIXFSLIB and USE_TURBOJPEG are not allowed to be enabled at
+    # the same time, so ujpeg.cpp is unconditionaly in this sources list:
     set(DCM2NIIXFSLIB_SRCS
         dcm2niix_fswrapper.cpp
         nii_dicom.cpp
@@ -195,11 +199,14 @@ if(BATCH_VERSION)
         main_console_batch.cpp
         nii_dicom.cpp
         jpg_0XC3.cpp
-        ujpeg.cpp
         nifti1_io_core.cpp
         nii_foreign.cpp
         nii_ortho.cpp
         nii_dicom_batch.cpp)
+
+    if(NOT USE_TURBOJPEG)
+        set(DCM2NIIBATCH_SRCS ${DCM2NIIBATCH_SRCS} ujpeg.cpp)
+    endif()
 
     if(USE_JNIFTI)
         set(DCM2NIIBATCH_SRCS ${DCM2NIIBATCH_SRCS} cJSON.cpp base64.cpp)

--- a/console/makefile
+++ b/console/makefile
@@ -26,9 +26,30 @@ endif
 
 #run "make" for default build
 #run "JPEGLS=1 make" for JPEGLS build
-JFLAGS=
-ifeq "$(JPEGLS)" "1"
-	JFLAGS=-std=c++14 -DmyEnableJPEGLS  charls/jpegls.cpp charls/jpegmarkersegment.cpp charls/interface.cpp  charls/jpegstreamwriter.cpp charls/jpegstreamreader.cpp
+#run "JPEGLS=2 make" for JPEGLS build with system CharLS
+# JPEGLS=0 : disable JPEG-LS
+# JPEGLS=1 : use local ./charls source files
+# JPEGLS=2 : use system-installed CharLS via pkg-config
+
+ifeq ($(JPEGLS),1)
+	CFLAGS += -DmyEnableJPEGLS
+	CHARLS_SRCS = charls/jpegls.cpp charls/jpegmarkersegment.cpp charls/interface.cpp \
+								charls/jpegstreamwriter.cpp charls/jpegstreamreader.cpp
+	CFILES := $(CHARLS_SRCS) $(CFILES)
+endif
+
+ifeq ($(JPEGLS),2)
+	CFLAGS += -DmyEnableJPEGLS
+	CHARLS_CFLAGS := $(shell pkg-config --cflags charls 2>/dev/null)
+	CHARLS_LIBS := $(shell pkg-config --libs charls 2>/dev/null)
+	ifeq ($(CHARLS_CFLAGS),)
+		CHARLS_CFLAGS := -I/usr/include -I/opt/homebrew/include
+	endif
+	ifeq ($(CHARLS_LIBS),)
+		CHARLS_LIBS := -lcharls -L/usr/lib -L/opt/homebrew/lib
+	endif
+	CFLAGS += $(CHARLS_CFLAGS)
+	CFILES += $(CHARLS_LIBS)
 endif
 
 #run "JNIfTI=0 make" to disable JNIFTI build

--- a/console/makefile
+++ b/console/makefile
@@ -26,30 +26,9 @@ endif
 
 #run "make" for default build
 #run "JPEGLS=1 make" for JPEGLS build
-#run "JPEGLS=2 make" for JPEGLS build with system CharLS
-# JPEGLS=0 : disable JPEG-LS
-# JPEGLS=1 : use local ./charls source files
-# JPEGLS=2 : use system-installed CharLS via pkg-config
-
-ifeq ($(JPEGLS),1)
-	CFLAGS += -DmyEnableJPEGLS
-	CHARLS_SRCS = charls/jpegls.cpp charls/jpegmarkersegment.cpp charls/interface.cpp \
-								charls/jpegstreamwriter.cpp charls/jpegstreamreader.cpp
-	CFILES := $(CHARLS_SRCS) $(CFILES)
-endif
-
-ifeq ($(JPEGLS),2)
-	CFLAGS += -DmyEnableJPEGLS
-	CHARLS_CFLAGS := $(shell pkg-config --cflags charls 2>/dev/null)
-	CHARLS_LIBS := $(shell pkg-config --libs charls 2>/dev/null)
-	ifeq ($(CHARLS_CFLAGS),)
-		CHARLS_CFLAGS := -I/usr/include -I/opt/homebrew/include
-	endif
-	ifeq ($(CHARLS_LIBS),)
-		CHARLS_LIBS := -lcharls -L/usr/lib -L/opt/homebrew/lib
-	endif
-	CFLAGS += $(CHARLS_CFLAGS)
-	CFILES += $(CHARLS_LIBS)
+JFLAGS=
+ifeq "$(JPEGLS)" "1"
+	JFLAGS=-std=c++14 -DmyEnableJPEGLS  charls/jpegls.cpp charls/jpegmarkersegment.cpp charls/interface.cpp  charls/jpegstreamwriter.cpp charls/jpegstreamreader.cpp
 endif
 
 #run "JNIfTI=0 make" to disable JNIFTI build

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -5743,6 +5743,8 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 				d.modality = kMODALITY_PT;
 			if ((buffer[lPos] == 'U') && (toupper(buffer[lPos + 1]) == 'S'))
 				d.modality = kMODALITY_US;
+			if ((buffer[lPos] == 'S') && (toupper(buffer[lPos + 1]) == 'E'))
+				d.modality = kMODALITY_SEG;
 			break;
 		case kManufacturer:
 			if (d.manufacturer == kMANUFACTURER_UNKNOWN)

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -5313,7 +5313,9 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 			lPos = lPos + 4;
 			// https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_8.2.html
 			// detect and skip  Basic Offset Table
-			bool  isBasicOffsetTable = (d.imageBytes < 1) && ((lLength == 4 * numberOfFrames) || (lLength <= 0));
+			bool isBasicOffsetTable = (d.imageBytes < 1) && ((lLength == 4 * numberOfFrames) || (lLength <= 0));
+			if ((numberOfFrames < 2) && (lLength == 4))
+				isBasicOffsetTable = true;
 			if (lLength == 0xFFFFFFFF) {
 				// printf("Fragment has undefined length\n");
 				// to do: see pixelmed microscopy https://www.aliza-dicom-viewer.com/download/datasets

--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -4828,6 +4828,7 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 	bool has00200013 = false;
 	// double contentTime = 0.0;
 	int echoTrainLengthPhil = 0;
+	float prePulseDelayPhil = 0;
 	int philMRImageDiffBValueNumber = 0;
 	int philMRImageDiffVolumeNumber = -1;
 	int sqDepth = 0;
@@ -7294,8 +7295,10 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 		case kPrepulseDelay: // FL
 			if (d.manufacturer != kMANUFACTURER_PHILIPS)
 				break;
-			d.TI = dcmFloat(lLength, &buffer[lPos], d.isLittleEndian);
-			break;
+			prePulseDelayPhil = dcmFloat(lLength, &buffer[lPos], d.isLittleEndian);
+			if (prePulseDelayPhil > 0.0f)
+				d.TI = prePulseDelayPhil;
+					break;
 		case kPrepulseType: // CS [INV]
 			if (d.manufacturer != kMANUFACTURER_PHILIPS)
 				break;

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -94,6 +94,7 @@ static const int kMaxDTI4D = kMaxSlice2D; // issue460: maximum number of DTI dir
 #define kMODALITY_MR 3
 #define kMODALITY_PT 4
 #define kMODALITY_US 5
+#define kMODALITY_SEG 6
 
 // PartialFourierDirection 0018,9036
 #define kPARTIAL_FOURIER_DIRECTION_UNKNOWN 0

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -57,7 +57,7 @@ extern "C" {
 #define kCPUsuf " " // unknown CPU
 #endif
 
-#define kDCMdate "v1.0.20250606"
+#define kDCMdate "v1.0.20250626"
 #define kDCMvers kDCMdate " " kJP2suf kTurbosuf kLSsuf kCCsuf kCPUsuf
 
 static const int kMaxEPI3D = 1024; // maximum number of EPI images in Siemens Mosaic

--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -57,7 +57,7 @@ extern "C" {
 #define kCPUsuf " " // unknown CPU
 #endif
 
-#define kDCMdate "v1.0.20250505"
+#define kDCMdate "v1.0.20250606"
 #define kDCMvers kDCMdate " " kJP2suf kTurbosuf kLSsuf kCCsuf kCPUsuf
 
 static const int kMaxEPI3D = 1024; // maximum number of EPI images in Siemens Mosaic

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -3932,7 +3932,8 @@ int nii_createFilename(struct TDICOMdata dcm, char *niiFilename, struct TDCMopts
 					strcat(outname, "NA");
 			}
 			if (f == 'W') { // Weird includes personal data in filename patientWeight
-				snprintf(newstr, PATH_MAX, "dob%sg%cwt%d", dcm.patientBirthDate, dcm.patientSex, (int)round(dcm.patientWeight));
+				printf("polo %s\n", dcm.bodyPartExamined);
+				snprintf(newstr, PATH_MAX, "part%sdob%sg%cwt%d", dcm.bodyPartExamined, dcm.patientBirthDate, dcm.patientSex, (int)round(dcm.patientWeight));
 				if (strstr(dcm.institutionName, "Richland"))
 					strcat(newstr, "R");
 				strcat(outname, newstr);
@@ -10006,7 +10007,7 @@ int nii_loadDirCore(char *indir, struct TDCMopts *opts) {
 		if (opts->isIgnoreSeriesInstanceUID)
 			dcmList[i].seriesUidCrc = dcmList[i].seriesNum;
 		// if (!dcmList[i].isValid) printf(">>>>Not a valid DICOM %s\n", nameList.str[i]);
-		if ((dcmList[i].isValid) && ((dti4D->sliceOrder[0] >= 0) || (dcmList[i].CSA.numDti > 1))) { // 4D dataset: dti4D arrays require huge amounts of RAM - write this immediately
+		if ((dcmList[i].isValid) && ((dcmList[i].xyzDim[4] > 1) || (dti4D->sliceOrder[0] >= 0) || (dcmList[i].CSA.numDti > 1))) { // 4D dataset: dti4D arrays require huge amounts of RAM - write this immediately
 			struct TDCMsort dcmSort[1];
 			fillTDCMsort(dcmSort[0], i, dcmList[i]);
 			dcmList[i].converted2NII = 1;

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -6881,8 +6881,9 @@ void sliceTimingXA(struct TDCMsort *dcmSort, struct TDICOMdata *dcmList, struct 
 	if (hdr->dim[3] > kMaxEPI3D) {
 		printWarning("Unable to set Siemens XA sliceTiming due to excessive slices per volume (%d).\n", hdr->dim[3]);
 		return;
-	} else {
-		printWarning("4D Siemens XA images should be exported as enhanced not classic DICOM. Slice times and other properties may be inaccurate.\n");
+	} else if (nConvert > hdr->dim[4]) {
+		// XA enhanced DICOM saves 1 file per 3D volume, classic DICOM saves multiple volumes
+		printWarning("4D Siemens XA images should be exported as enhanced not classic DICOM. Slice times and other properties may be inaccurate %d.\n");
 	}
 	if ((nConvert == (hdr->dim[3] * hdr->dim[4])) && (hdr->dim[3] < (kMaxEPI3D - 1)) && (hdr->dim[3] > 1)) {
 		// issue875 use 2nd volume

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -6883,7 +6883,7 @@ void sliceTimingXA(struct TDCMsort *dcmSort, struct TDICOMdata *dcmList, struct 
 		return;
 	} else if (nConvert > hdr->dim[4]) {
 		// XA enhanced DICOM saves 1 file per 3D volume, classic DICOM saves multiple volumes
-		printWarning("4D Siemens XA images should be exported as enhanced not classic DICOM. Slice times and other properties may be inaccurate %d.\n");
+		printWarning("4D Siemens XA images should be exported as enhanced not classic DICOM. Slice times and other properties may be inaccurate.\n");
 	}
 	if ((nConvert == (hdr->dim[3] * hdr->dim[4])) && (hdr->dim[3] < (kMaxEPI3D - 1)) && (hdr->dim[3] > 1)) {
 		// issue875 use 2nd volume

--- a/license.txt
+++ b/license.txt
@@ -18,27 +18,25 @@ Jasper is optional and provides its own license
 
 ---
 The Software has been developed for research purposes only and is not a clinical tool
-Copyright (c) 2014-2021 Chris Rorden. All rights reserved.
+Copyright (c) 2014-2025 Chris Rorden. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the distribution.
-3. Neither the name of the copyright owner nor the name of this project
-   (dcm2niix) may be used to endorse or promote products derived from this
-   software without specific prior written permission.
+modification, are permitted provided that the following conditions are met:
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT OWNER ``AS IS'' AND ANY EXPRESS OR
-IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO
-EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools_scm>=7", "scikit-build-core[pyproject]>=0.5"]
+requires = ["setuptools_scm>=7", "scikit-build-core>=0.11"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools_scm>=7", "scikit-build-core>=0.11"]
+requires = [
+  "setuptools_scm>=7",
+  "scikit-build-core>=0.11; python_version >= '3.9'",
+  "scikit-build-core[pyproject]>=0.5; python_version < '3.9'"
+]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
In R11 it seems Philips is always providing private tag [(0021,010B) - prepulse delay], even when it has value 0. In dcm2niix the prepulse delay overwrites the inversion time container (d.TI) if the tag is present, leading to d.TI=0.0. As a result the inversionTime is not populated in the json sidecar.  

The pull request changes the behavior of dcm2niix to only overwrite d.TI in case the prepulse delay has a value different from 0.0.

I have verified the fix working on a dataset from R11.1.0 I have access to but I unfortunately can't share.