### PR TITLE
bvec signs for GE DTI with Coronol + ROW (#970)

### DIFF
--- a/console/nii_dicom.h
+++ b/console/nii_dicom.h
@@ -57,7 +57,7 @@ extern "C" {
 #define kCPUsuf " " // unknown CPU
 #endif
 
-#define kDCMdate "v1.0.20250626"
+#define kDCMdate "v1.0.20250827"
 #define kDCMvers kDCMdate " " kJP2suf kTurbosuf kLSsuf kCCsuf kCPUsuf
 
 static const int kMaxEPI3D = 1024; // maximum number of EPI images in Siemens Mosaic

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -303,6 +303,12 @@ void geCorrectBvecs(struct TDICOMdata *d, int sliceDir, struct TDTI *vx, int isV
 	if (abs(sliceDir) != 3)
 		printWarning("Limited validation for non-Axial DTI: confirm gradient vector transformation.\n");
 	// GE vectors from Xiangrui Li' dicm2nii, validated with datasets from https://www.nitrc.org/plugins/mwiki/index.php/dcm2nii:MainPage#Diffusion_Tensor_Imaging
+	//
+	// GE → FSL bvec (see issue 970) for unit vector
+	// 1) Apply plane-dependent flip first
+	// 2) Always negate Y
+	// 3) ROW swap/flip (if !col)
+	// 4) Negate all components (compatibility)
 	ivec3 flp;
 	if (abs(sliceDir) == 1)
 		flp = setiVec3(1, 1, 0); // SAGITTAL
@@ -353,18 +359,19 @@ void geCorrectBvecs(struct TDICOMdata *d, int sliceDir, struct TDTI *vx, int isV
 			vx[i].V[2] = vx[i].V[2] * bVecScale;
 			vx[i].V[3] = vx[i].V[3] * bVecScale;
 		}
+		for (int v = 0; v < 3; v++)
+			if (flp.v[v] == 1)
+				vx[i].V[v + 1] = -vx[i].V[v + 1];
+		vx[i].V[2] = -vx[i].V[2]; // we read out Y-direction opposite order as dicm2nii, see also opts.isFlipY
+		// 3) ROW swap/flip (if !col) (see issue 970)
 		if (!col) { // rows need to be swizzled
 					// see Stanford dataset Ax_DWI_Tetrahedral_7 unable to resolve between possible solutions
 					//  http://www.nitrc.org/plugins/mwiki/index.php/dcm2nii:MainPage#Diffusion_Tensor_Imaging
 			float swap = vx[i].V[1];
 			vx[i].V[1] = vx[i].V[2];
 			vx[i].V[2] = swap;
-			vx[i].V[2] = -vx[i].V[2]; // because of transpose?
-		}
-		for (int v = 0; v < 3; v++)
-			if (flp.v[v] == 1)
-				vx[i].V[v + 1] = -vx[i].V[v + 1];
-		vx[i].V[2] = -vx[i].V[2]; // we read out Y-direction opposite order as dicm2nii, see also opts.isFlipY
+			vx[i].V[1] = -vx[i].V[1]; // because of transpose?
+		}		
 	}
 	// These next lines are only so files appear identical to old versions of dcm2niix:
 	//  dicm2nii and dcm2niix generate polar opposite gradient directions.


### PR DESCRIPTION
## Summary
`dcm2niix` (v1.0.20250626) produces **incorrect bvec signs** for **GE DTI acquired with Coronal + ROW phase-encoding** (with warnings). Other plane/phase combinations appear correct (Axial/Sagittal with COL/ROW and Coronal with COL).

**Root cause:** For Coronal + ROW, performing the **ROW swap/negate before** the plane-flip yields an incorrect combination of sign flips.

**Proposed fix:** Apply the **plane‑dependent flip first**, then apply the ROW remap, and negate the first element after the swap. This preserves existing, validated behavior for all other cases while correcting Coronal+ROW.

**Impact:** Affects **GE DTI with Coronal+ROW** only


**Order Change:**
```
**BEFORE**: ROW → plane‑dependent flip → always-negate-Y → negate-all
**AFTER**:  plane‑dependent flip → always-negate-Y → ROW → negate-all
```

**Implementation (GE → FSL bvec)**
While dcm2niix GE → FSL bvec code is somewhat complicated (derived from xiangruili's dicm2nii) with some differences:
- Y-direction handled opposite to dicm2nii
- Negate all components for compatibility

**Current sequence**:
  1. ROW swap first (if !col)
    - swap X ↔ Y, then negate Y
  2. Apply plane-dependent flip
  3. Always negate Y
  4. Negate all components (compatibility)

**Proposed sequence:**
  1. Apply plane-dependent flip first
  2. Always negate Y
  3. ROW swap last (if !col)
    - swap X ↔ Y, then negate X
  4. Negate all components (compatibility)

**See #970 for Validation Results and Investigation Details**