### PR TITLE
ENH: Build abi3 wheels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,17 @@
 name: Release
-on: {push: {branches: [development], tags: [v*.*.*]}}
+on: {push: {branches: [development], tags: [v*.*.*]}, pull_request: {branches: [development]}}
 jobs:
   wheels:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        # macos-15 is an intel runner, macos-latest is apple silicon
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-latest]
     steps:
     - uses: actions/checkout@v4
       with: {fetch-depth: 0, submodules: false}
     - uses: pypa/cibuildwheel@2.x
       with: {output-dir: dist}
-      env: {CIBW_ARCHS: auto64, CIBW_SKIP: pp*}  # skip 32bit & PyPy
     - uses: actions/upload-artifact@v4
       with:
         name: wheels-${{ matrix.os }}-${{ strategy.job-index }}
@@ -31,6 +30,7 @@ jobs:
         pattern: wheels-*
         path: dist
         merge-multiple: true
+    - run: pipx run twine check --strict dist/*
     - uses: casperdcl/deploy-pypi@v2
       with:
         build: -s

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,15 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 sdist.include = ["dcm2niix/_dist_ver.py"]
 minimum-version = "0.5"
 cmake.minimum-version = "3.18"
+wheel.py-api = "cp38"
 
 [tool.setuptools_scm]
 write_to = "dcm2niix/_dist_ver.py"
 write_to_template = "__version__ = '{version}'\n"
+
+[tool.cibuildwheel]
+archs = "auto64"
+build = "cp38-*"
 
 [project]
 name = "dcm2niix"


### PR DESCRIPTION
It's great that there are now wheels! But no point in having ones for different versions of Python since the Python code is just a wrapper around a binary. This uses ABI3 mode to create a single `-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl` wheel that is future compatible with newer versions of Python. Faster build time, less PyPI storage use, and future compat. No real downsides AFAIK. I used 3.8 as the min because that's the minimum `cibuildwheel` now supports.

In the process I moved some `cibuildwheel` config options to `pyproject.toml` so I could test locally by just doing:
```
cibuildwheel .
```
without those changes, I'd need to set env vars myself.

I then made the wheel building step run on PRs to make sure `cibuildwheel` still works. It should be plenty fast I think.

Then I updated from `macos-13` which is deprecated to `macos-15-intel` and `macos-14` to `macos-latest` according to latest cibuildwheel recommendations.

There are some opinionated changes in here -- happy to revert them if desired!