### PR TITLE
Multi Frame 3D Effective Echo Time parsing

### DIFF
--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -6762,7 +6762,7 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 			break;
 		case kEffectiveTE: {
 			TE = dcmFloatDouble(lLength, &buffer[lPos], d.isLittleEndian);
-			if (d.TE <= 0.0)
+			// if (d.TE <= 0.0)
 				d.TE = TE;
 			break;
 		}


### PR DESCRIPTION
Hi there!

I'm using `dcm2niix` as a part of the `heudiconv` workflow and trying to parse a Multi Frame 3D enhanced MR DICOM image. One issue that I'm having while running `dcm2niix` is that it only outputs the very first echo time in its json output. But when I remove `if` statement (like I've done in this PR), it outputs three json files per effective echo time. Is there a better way to handle multiple effective echo times, and or is this the right way?

I'd really appreciate any help with this. Thank you!

Code:
```
dcm2niix -o outputfolder /path/to/.dcm
```  

Here's a dicom that I'm using: https://github.com/Dhananjhay/dcm2niix/blob/f5b1fc4ccaa885eccb3112c80fb4ba4215b81eee/test_data/176F1.MR.PRADO%5EVACCIBV.100001.0001.20250403.81D8606A.dcm