### PR TITLE
Add number of volumes to json

### DIFF
--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -1779,6 +1779,10 @@ tse3d: T2*/
 		} else
 			fprintf(fp, "\t\"EchoTime\": %g,\n", d.TE / 1000.0);
 	}
+	
+	if (h->dim[4] >= 1)
+		fprintf(fp, "\t\"VolumesInDicomSeries\": %d,\n", h->dim[4]);
+	
 	// if ((d.TE2 > 0.0) && (!d.isXRay)) fprintf(fp, "\t\"EchoTime2\": %g,\n", d.TE2 / 1000.0 );
 	if (dti4D->frameDuration[0] < 0.0) // e.g. PET scans can have variable TR
 		json_Float(fp, "\t\"RepetitionTime\": %g,\n", d.TR / 1000.0);


### PR DESCRIPTION
Adds "VolumesInDicomSeries" to json file. 

Likely breaks some rule of bids, but having a field for identifying the _original_ number of volumes in the DICOM stream that was converted is useful for at least two purposes: 1) sorting out incomplete multi-volume scans (e.g. BOLD, DWI) with tools such as dcm2bids; 2) double check for "did someone remove volumes from the original scan before data sharing". 

Inspired by trying to create more automated methods for BIDS conversion using data platforms like XNAT. 