### PR TITLE
Fix incorrect bvec orientation for Canon DWI data

### DIFF
--- a/console/nii_dicom.cpp
+++ b/console/nii_dicom.cpp
@@ -8479,7 +8479,7 @@ struct TDICOMdata readDICOMx(char *fname, struct TDCMprefs *prefs, struct TDTI4D
 		strcpy(d.seriesInstanceUID, seriesTimeTxt); // dest <- src
 		d.seriesUidCrc = mz_crc32X((unsigned char *)&seriesTimeTxt, strlen(seriesTimeTxt));
 	}
-	if (((d.manufacturer == kMANUFACTURER_TOSHIBA) || (d.manufacturer == kMANUFACTURER_CANON)) && (B0Philips > 0.0)) { // issue 388
+	if (((d.manufacturer == kMANUFACTURER_TOSHIBA) || (d.manufacturer == kMANUFACTURER_CANON)) && (B0Philips > 0.0) && (!d.isBVecWorldCoordinates)) { // issue 388
 		char txt[1024] = {""};
 		snprintf(txt, 1024, "b=%d(", (int)round(B0Philips));
 		if (strstr(d.imageComments, txt) != NULL) {


### PR DESCRIPTION
When converting Canon DWI DICOM data, dcm2niix incorrectly generates bvec files if both of the following DICOM tags are present:
- Image Comments (0020,4000): contains diffusion gradient vectors in image space
- DiffusionGradientOrientation (0018,9089): contains gradient vectors in scanner space

The bug occurs because dcm2niix reads the gradient vectors from the Image Comments tag (0020,4000) and applies the siemensPhilipsCorrectBvecs function, which rotates vectors from scanner space to image space. However, for Canon data from this tag, these vectors are already in scanner space and should not undergo this transformation, resulting in incorrect bvec values.

This fix enables the code to correctly handle Canon DWI data regardless of which DICOM tags are populated: (0020,4000), (0018,9089), or both.