### PR TITLE
DCM2NIIXFSLIB changes

### DIFF
--- a/console/dcm2niix_fswrapper.cpp
+++ b/console/dcm2niix_fswrapper.cpp
@@ -242,6 +242,11 @@ MRIFSSTRUCT *dcm2niix_fswrapper::getMrifsStruct(void) {
 	return nii_getMrifsStruct();
 }
 
+// interface to nii_dicom_batch.cpp::nii_getAutoScaleFactorVector()
+std::vector<std::vector<float>> *dcm2niix_fswrapper::getAutoScaleFactorVector() {
+        return nii_getAutoScaleFactorVector();
+}
+
 // interface to nii_dicom_batch.cpp::nii_getMrifsStructVector()
 std::vector<MRIFSSTRUCT> *dcm2niix_fswrapper::getMrifsStructVector(void) {
 	return nii_getMrifsStructVector();
@@ -295,8 +300,8 @@ void dcm2niix_fswrapper::dicomDump(const char *dicomdir, const char *series_info
 			fprintf(fp_dcmLst, "%s\n", (*mrifsStruct_vector)[n].dicomlst[nDcm]);
 		fclose(fp_dcmLst);
 
-		// output series_info
-		fprintf(fpout, "%ld %s %f %f %f %f\\%f %c %f %s %s %s",
+		// output series_info as csv file
+		fprintf(fpout, "%ld,%s,%f,%f,%f,%f\\%f,%c,%f,%s,%s,%s",
 				tdicomData->seriesNum, tdicomData->seriesDescription,
 				tdicomData->TE, tdicomData->TR, tdicomData->flipAngle, tdicomData->xyzMM[1], tdicomData->xyzMM[2],
 				tdicomData->phaseEncodingRC, tdicomData->pixelBandwidth, (*mrifsStruct_vector)[n].dicomfile, tdicomData->imageType, (*mrifsStruct_vector)[n].pulseSequenceDetails);
@@ -307,8 +312,9 @@ void dcm2niix_fswrapper::dicomDump(const char *dicomdir, const char *series_info
       fprintf(fpout, " max-value");
     }
 #endif
+                // output as csv
 		if (extrainfo)
-			fprintf(fpout, " %s %s %s %s %f %s", tdicomData->patientName, tdicomData->studyDate, mfrCode2Str(tdicomData->manufacturer), tdicomData->manufacturersModelName, tdicomData->fieldStrength, tdicomData->deviceSerialNumber);
+			fprintf(fpout, ",%s,%s,%s,%s,%f,%s", tdicomData->patientName, tdicomData->studyDate, mfrCode2Str(tdicomData->manufacturer), tdicomData->manufacturersModelName, tdicomData->fieldStrength, tdicomData->deviceSerialNumber);
 
 		fprintf(fpout, "\n");
 	}

--- a/console/dcm2niix_fswrapper.h
+++ b/console/dcm2niix_fswrapper.h
@@ -37,6 +37,9 @@ class dcm2niix_fswrapper {
 	// return nifti header saved in MRIFSSTRUCT
 	static nifti_1_header *getNiiHeader(void);
 
+        // interface to nii_dicom_batch.cpp::nii_getAutoScaleFactorVector()
+        static std::vector<std::vector<float>> *getAutoScaleFactorVector();
+
 	// interface to nii_dicom_batch.cpp::nii_getMrifsStructVector()
 	static std::vector<MRIFSSTRUCT> *getMrifsStructVector(void);
 

--- a/console/nifti1_io_core.h
+++ b/console/nifti1_io_core.h
@@ -62,8 +62,10 @@ bool littleEndianPlatform();
 vec3 nifti_mat33_eig3(double bxx, double bxy, double bxz, double byy, double byz, double bzz);
 mat33 nifti_mat33_transpose(mat33 A);
 mat44 nifti_dicom2mat(float orient[7], float patientPosition[4], float xyzMM[4]);
+#ifndef LINKING_FREESURFER
 // issue908: hide visibility of functions that conflict with nifti2_io.h
 #pragma GCC visibility push(hidden)
+#endif
 float nifti_mat33_determ(mat33 R);
 mat33 nifti_mat33_inverse(mat33 R);
 mat33 nifti_mat33_mul(mat33 A, mat33 B);
@@ -79,7 +81,9 @@ void nifti_mat44_to_quatern(mat44 R,
 mat44 nifti_quatern_to_mat44(float qb, float qc, float qd,
 							 float qx, float qy, float qz,
 							 float dx, float dy, float dz, float qfac);
+#ifndef LINKING_FREESURFER
 #pragma GCC visibility pop
+#endif
 vec3 crossProduct(vec3 u, vec3 v);
 vec3 nifti_vect33_norm(vec3 v);
 vec4 nifti_vect44_norm(vec4 v);

--- a/console/nii_dicom_batch.cpp
+++ b/console/nii_dicom_batch.cpp
@@ -114,6 +114,13 @@ const char kFileSep[2] = "/";
 // no .nii, .bval, .bvec are created.
 MRIFSSTRUCT mrifsStruct;
 std::vector<MRIFSSTRUCT> mrifsStruct_vector;
+std::vector<std::vector<float>> autoscalefactor_vector;  // autoscale factor for each slice
+
+// retrieve autoscalefactor_vector
+std::vector<std::vector<float>> *nii_getAutoScaleFactorVector()
+{
+        return &autoscalefactor_vector;
+}
 
 // retrieve the struct
 MRIFSSTRUCT *nii_getMrifsStruct() {
@@ -8280,6 +8287,7 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata d
 #endif
 
 #ifdef USING_DCM2NIIXFSWRAPPER
+	std::vector<float> ascalefactors;
 	mrifsStruct.tdicomData = dcmList[indx]; // first in sorted list dcmSort
 #endif
 
@@ -8685,8 +8693,22 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata d
 				free(img);
 
 #ifdef USING_DCM2NIIXFSWRAPPER
+                                /* At the MGH Martinos scanners, AutoScale functor scales data before saving them to DICOM.
+                                 * The scale factor is saved in DICOM tag (0020, 4000). Dcm2niix retrieves (0020, 4000) as image comments,
+                                 * and saves it in nifti header field aux_file. The string format is `Scale Factor: %f`.
+                                 *
+                                 * Save the scale factors for each slice.
+                                 * Freesurfer mri_convert uses the scale factors to undo the scaling applied by AutoScale functor.
+                                 */
+                                const char *AutoScale_Key = "Scale Factor:";
+                                float ascale_factor = 1.0;
+                                if (strncmp(hdrI.aux_file, AutoScale_Key, strlen(AutoScale_Key)) == 0)
+                                {
+                                        ascale_factor = (float)strtod(&(hdrI.aux_file[strlen(AutoScale_Key) + 1]), NULL);
+                                        ascalefactors.push_back(ascale_factor);
+                                }				
 				if (opts.isVerbose)
-					printMessage("load Image #%d %s\n", i, nameList->str[indx]);
+					printMessage("(verbose) load Image #%d %s (autoscale factor: %f)\n", i, nameList->str[indx], ascale_factor);
 #endif
 			}
 		} // skip if we are only creating BIDS
@@ -9045,6 +9067,7 @@ int saveDcm2NiiCore(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata d
 	mrifsStruct.imgM = imgM;
 
 	mrifsStruct_vector.push_back(mrifsStruct);
+	autoscalefactor_vector.push_back(ascalefactors);
 #else
 	free(imgM);
 #endif
@@ -10763,22 +10786,24 @@ void saveIniFile(struct TDCMopts opts) {
 // the following fields from struct TDICOMdata are printed:
 //   patientName  seriesNum  studyDate  studyTime  TE  TR  flipAngle  xyzMM[1]\xyzMM[2]  phaseEncodingRC  pixelBandwidth  dicom-file  imageType
 void dcmListDump(int nConvert, struct TDCMsort dcmSort[], struct TDICOMdata dcmList[], struct TSearchList *nameList, struct TDCMopts opts) {
+        FILE *fp = stdout;
+	const char *imagelist = getenv("MGH_DCMUNPACK_IMAGELIST");
+	if (imagelist != NULL)
+	        fp = fopen(imagelist, "a");
 	for (int i = 0; i < nConvert; i++) {
 		int indx = dcmSort[i].indx;
 		mrifsStruct.dicomlst[i] = new char[strlen(nameList->str[indx]) + 1];
 		memset(mrifsStruct.dicomlst[i], 0, strlen(nameList->str[indx]) + 1);
 		memcpy(mrifsStruct.dicomlst[i], nameList->str[indx], strlen(nameList->str[indx]));
 
-		FILE *fp = stdout;
-		const char *imagelist = getenv("MGH_DCMUNPACK_IMAGELIST");
-		if (imagelist != NULL)
-				fp = fopen(imagelist, "a");
-		fprintf(fp, "%s %ld %s %s %f %f %f %f\\%f %c %f %s %s\n",
+                // output imagelist as csv file
+		fprintf(fp, "%s,%ld,%s,%s,%f,%f,%f,%f\\%f,%c,%f,%s,%s\n",
 				dcmList[indx].patientName, dcmList[indx].seriesNum, dcmList[indx].studyDate, dcmList[indx].studyTime,
 				dcmList[indx].TE, dcmList[indx].TR, dcmList[indx].flipAngle, dcmList[indx].xyzMM[1], dcmList[indx].xyzMM[2],
 				dcmList[indx].phaseEncodingRC, dcmList[indx].pixelBandwidth, nameList->str[indx], dcmList[indx].imageType);
-		if (fp != stdout)
-			fclose(fp);
 	}
+	if (fp != stdout)
+		fclose(fp);
+
 }
 #endif

--- a/console/nii_dicom_batch.h
+++ b/console/nii_dicom_batch.h
@@ -27,6 +27,8 @@ struct MRIFSSTRUCT {
 	int numDti;
 };
 
+std::vector<std::vector<float>> *nii_getAutoScaleFactorVector();
+
 MRIFSSTRUCT *nii_getMrifsStruct();
 void nii_clrMrifsStruct();
 


### PR DESCRIPTION
  1. freesurfer commit ee02fa4, Feb 04, 2026  
     (https://github.com/freesurfer/freesurfer/commit/ee02fa4bd1a328874068b204e1f60d1a9447bd2d) 
    - handle dicom files with space in the names when using dcm2niix for pre-processing    
      nii_dicom_batch.cpp/dcm2niix_fswrapper.cpp: output imagelist and series-info as csv
  2. freesurfer commit 6e75365, May 31, 2025 
     (https://github.com/freesurfer/freesurfer/commit/6e7536546a7fd7f67de7cc56a62da97635647b22)
     - Undo AutoScale Functor in dcm2niix conversion
       At the Martinos scanners, AutoScale functor scales data before saving them to DICOM. The scale factor is saved in DICOM tag (0020, 4000). Dcm2niix retrieves (0020, 4000) as image comments, and saves it in nifti header field aux_file. The string format is `Scale Factor: %f`.

       a. Retrieve the scale factors for each slice saved in dcm2niix - nii_dicom_batch.cpp::saveDcm2NiiCore().
       b. The scale factors are used to undo the scaling applied by AutoScale functor in Freesurfer.
  3. freesurfer commit 715964c, Mar 13, 2025 
      (https://github.com/freesurfer/freesurfer/commit/715964c03aee2657f40d627d205e57d20b29ed51)
      - fix packages/dcm2niix/nii_dicom_batch.cpp::dcmListDump()
        open MGH_DCMUNPACK_IMAGELIST to append once per call