### PR TITLE
build: Only pass "-dead_strip" to Apple linker.

### DIFF
--- a/console/CMakeLists.txt
+++ b/console/CMakeLists.txt
@@ -25,7 +25,9 @@ if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     add_definitions(-fno-caret-diagnostics)
     # issue867 reduce stack pressure
     # set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip -Wl,-stack_size -Wl,0x1000000")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip")
+    if(APPLE)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-dead_strip")
+    endif()
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     # using GCC
     if(NOT (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 7.1.0))


### PR DESCRIPTION
This fixes the build on OpenBSD and other systems that use Clang but whose linker does not support "-dead_strip".

* console/CMakeLists.txt: Only pass "-dead_strip" to the linker when the target system is Apple.